### PR TITLE
Dls 6994 leading trailing white space

### DIFF
--- a/app/forms/mappings/Formatters.scala
+++ b/app/forms/mappings/Formatters.scala
@@ -31,7 +31,7 @@ trait Formatters {
       data.get(key) match {
         case None                      => Left(Seq(FormError(key, errorKey, args)))
         case Some(s) if s.trim.isEmpty => Left(Seq(FormError(key, errorKey, args)))
-        case Some(s)                   => Right(s)
+        case Some(s)                   => Right(s.trim)
       }
 
     override def unbind(key: String, value: String): Map[String, String] =

--- a/test/forms/mappings/MappingsSpec.scala
+++ b/test/forms/mappings/MappingsSpec.scala
@@ -78,6 +78,26 @@ class MappingsSpec extends AnyFreeSpec with Matchers with OptionValues with Mapp
       val result = testForm.fill("foobar")
       result.apply("value").value.value mustEqual "foobar"
     }
+
+    "must remove leading whitespace and bind a valid string" in {
+        val result = testForm.bind(Map("value" -> " foobar"))
+        result.get mustEqual "foobar"
+      }
+
+    "must remove trailing whitespace and bind a valid string" in {
+      val result = testForm.bind(Map("value" -> "foobar "))
+      result.get mustEqual "foobar"
+    }
+
+    "must remove leading and trailing whitespace and bind a valid string" in {
+      val result = testForm.bind(Map("value" -> " foobar "))
+      result.get mustEqual "foobar"
+    }
+    "must remove leading and trailing whitespace but not between words, and bind a valid string" in {
+      val result = testForm.bind(Map("value" -> " foo bar "))
+      result.get mustEqual "foo bar"
+    }
+
   }
 
   "boolean" - {
@@ -127,6 +147,11 @@ class MappingsSpec extends AnyFreeSpec with Matchers with OptionValues with Mapp
 
     "must bind a valid integer" in {
       val result = testForm.bind(Map("value" -> "1"))
+      result.get mustEqual 1
+    }
+
+    "must bind a valid integer regardless of leading and trailing whitespace" in {
+      val result = testForm.bind(Map("value" -> " 1 "))
       result.get mustEqual 1
     }
 


### PR DESCRIPTION
.trim added to stringFormatter in formatting.scala file.  This method is called as base formatter for other methods.  Performed manual browser checks on strings and numbers and verified that white space between words are not affected.  