### PR TITLE
DLS-7548 - update code to removal all possible warnings / depreciations

### DIFF
--- a/app/controllers/AddASmallProducerController.scala
+++ b/app/controllers/AddASmallProducerController.scala
@@ -163,13 +163,13 @@ class AddASmallProducerController @Inject()(
                             (implicit hc: HeaderCarrier): Future[Either[SDILReferenceErrors, Unit]] = {
 
     if (currentSDILRef == addASmallProducerSDILRef) {
-      Future.successful(Right())
+      Future.successful(Right(()))
     } else if (smallProducerList.map(_.sdilRef).contains(addASmallProducerSDILRef)) {
       Future.successful(Left(AlreadyExists))
     } else {
       sdilConnector.checkSmallProducerStatus(addASmallProducerSDILRef, returnPeriod.get).map {
         case Some(false) => Left(NotASmallProducer)
-        case _ => Right()
+        case _ => Right(())
       }
     }
   }

--- a/app/controllers/AddASmallProducerController.scala
+++ b/app/controllers/AddASmallProducerController.scala
@@ -135,7 +135,8 @@ class AddASmallProducerController @Inject()(
                 )
               case Left(NotASmallProducer) =>
                 Future.successful(
-                  BadRequest(view(form.withError(FormError("referenceNumber", "addASmallProducer.error.referenceNumber.notASmallProducer")), mode, Some(sdilReference)))
+                  BadRequest(view(form.withError(FormError("referenceNumber", "addASmallProducer.error.referenceNumber.notASmallProducer")),
+                    mode, Some(sdilReference)))
                 )
               case Right(_) =>
                 updateSmallProducerList(formData, userAnswers, sdilReference).map(updatedAnswersFinal =>

--- a/app/controllers/actions/IdentifierAction.scala
+++ b/app/controllers/actions/IdentifierAction.scala
@@ -49,7 +49,7 @@ class AuthenticatedIdentifierAction @Inject()(
       val maybeSdil = getSdilEnrolment(enrolments)
       (maybeSdil, maybeUtr) match {
         case (None, None) =>
-          Future.successful(Redirect(routes.UnauthorisedController.onPageLoad))
+          Future.successful(Redirect(routes.UnauthorisedController.onPageLoad()))
         case (Some(sdil), _) =>
           sdilConnector.retrieveSubscription(sdil.value, "sdil").flatMap {
             case Some(sub) => sdilConnector.oldestPendingReturnPeriod(sub.utr).flatMap { optReturnPeriod =>
@@ -57,7 +57,7 @@ class AuthenticatedIdentifierAction @Inject()(
             }
             case None =>
               //ToDo redirect to current sdilFrontend
-              Future.successful(Redirect(routes.UnauthorisedController.onPageLoad))
+              Future.successful(Redirect(routes.UnauthorisedController.onPageLoad()))
           }
         case (None, Some(utr)) => sdilConnector.retrieveSubscription(utr, "utr").flatMap {
           case Some(sub) => sdilConnector.oldestPendingReturnPeriod(sub.utr).flatMap { optReturnPeriod =>
@@ -65,7 +65,7 @@ class AuthenticatedIdentifierAction @Inject()(
           }
           case None =>
             //ToDo redirect to current sdilFrontend
-            Future.successful(Redirect(routes.UnauthorisedController.onPageLoad))
+            Future.successful(Redirect(routes.UnauthorisedController.onPageLoad()))
         }
       }
     } recover {

--- a/app/models/SdilReturn.scala
+++ b/app/models/SdilReturn.scala
@@ -32,7 +32,7 @@ case class SdilReturn(
                        packSmall: List[SmallProducer],
                        importLarge: (Long, Long),
                        importSmall: (Long, Long),
-                       export: (Long, Long),
+                       `export`: (Long, Long),
                        wastage: (Long, Long),
                        submittedOn: Option[LocalDateTime] = None
                      ) {

--- a/app/models/package.scala
+++ b/app/models/package.scala
@@ -139,6 +139,7 @@ package object models {
                 }
               }
           }
+        case (_, _) => JsError("unexpected data provided")
       }
     }
   }

--- a/app/navigation/Navigator.scala
+++ b/app/navigation/Navigator.scala
@@ -55,7 +55,7 @@ class Navigator @Inject()() {
     case BrandsPackagedAtOwnSitesPage => _ => _ => _ => _ => routes.PackagedContractPackerController.onPageLoad(NormalMode)
     case PackagedContractPackerPage => userAnswers => _ => _ => _ => packagedContractPackerPageNavigation(userAnswers)
     case OwnBrandsPage => userAnswers => _ => _ => _ => ownBrandPageNavigation(userAnswers)
-    case _ => _ => _ => _ => _ => routes.IndexController.onPageLoad
+    case _ => _ => _ => _ => _ => routes.IndexController.onPageLoad()
   }
 
   private val checkRouteMap: Page => UserAnswers => Call = {

--- a/app/views/CheckYourAnswersView.scala.html
+++ b/app/views/CheckYourAnswersView.scala.html
@@ -55,7 +55,7 @@
     <h2 class="govuk-heading-m" id="sendYourReturn">@messages("sendYourReturn")</h2>
     <p class="govuk-body govuk-!-margin-bottom-5" id="sendYourReturnConfirmation">@messages("sendYourReturnConfirmation")</p>
 
-    @formHelper(action = submitCall, 'autoComplete -> "off") {
+    @formHelper(action = submitCall, Symbol("autoComplete") -> "off") {
         @govukButton(ButtonViewModel(messages("confirmDetailsAndSendReturn")))
     }
     <p class = "govuk-body-m" id="printPage">

--- a/app/views/RemovePackagingDetailsConfirmationView.scala.html
+++ b/app/views/RemovePackagingDetailsConfirmationView.scala.html
@@ -27,7 +27,7 @@
 @layout(pageTitle = title(form, messages("removePackagingDetailsConfirmation.title"))) {
 
 
-    @formHelper(action = routes.RemovePackagingDetailsConfirmationController.onSubmit(ref = addressRef), 'autoComplete -> "off") {
+    @formHelper(action = routes.RemovePackagingDetailsConfirmationController.onSubmit(ref = addressRef), Symbol("autoComplete") -> "off") {
 
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form))

--- a/app/views/RemoveWarehouseConfirmView.scala.html
+++ b/app/views/RemoveWarehouseConfirmView.scala.html
@@ -25,7 +25,7 @@ govukButton: GovukButton
 @(form: Form[_], mode: Mode, address: Html, index: String)(implicit request: Request[_], messages: Messages)
 
 @layout(pageTitle = title(form, messages("removeWarehouseConfirm.title"))) {
-    @formHelper(action = routes.RemoveWarehouseConfirmController.onSubmit(index), 'autoComplete -> "off") {
+    @formHelper(action = routes.RemoveWarehouseConfirmController.onSubmit(index), Symbol("autoComplete") -> "off") {
 
         @if(form.errors.nonEmpty) {
         @govukErrorSummary(ErrorSummaryViewModel(form))

--- a/build.sbt
+++ b/build.sbt
@@ -55,7 +55,7 @@ lazy val root = (project in file("."))
         ))
     ),
     // scalacOptions += "-deprecation",
-    scalacOptions ++= Seq("-Ypatmat-exhaust-depth", "off"),
+    scalacOptions ++= Seq("-Ypatmat-exhaust-depth", "off", "-unchecked", "-deprecation"),
     // prevent removal of unused code which generates warning errors due to use of third-party libs
     uglifyCompressOptions := Seq("unused=false", "dead_code=false"),
     pipelineStages := Seq(digest),

--- a/build.sbt
+++ b/build.sbt
@@ -55,7 +55,7 @@ lazy val root = (project in file("."))
         ))
     ),
     // scalacOptions += "-deprecation",
-    scalacOptions ++= Seq("-Ypatmat-exhaust-depth", "off", "-unchecked", "-deprecation"),
+    scalacOptions ++= Seq("-Ypatmat-exhaust-depth", "off"),
     // prevent removal of unused code which generates warning errors due to use of third-party libs
     uglifyCompressOptions := Seq("unused=false", "dead_code=false"),
     pipelineStages := Seq(digest),

--- a/it/controllers/AddASmallProducerControllerIntergrationSpec.scala
+++ b/it/controllers/AddASmallProducerControllerIntergrationSpec.scala
@@ -80,13 +80,13 @@ class AddASmallProducerControllerIntergrationSpec extends Specifications with Te
       given
         .commonPrecondition
 
-      WsTestClient.withClient { client ⇒
+      WsTestClient.withClient { client =>
         val result1 = client.url(s"$baseUrl/add-small-producer-edit?sdilReference=$sdilRefSuperCola")
           .withFollowRedirects(false)
           .addCookies(DefaultWSCookie("mdtp", authAndSessionCookie))
           .get()
 
-        whenReady(result1) { res ⇒
+        whenReady(result1) { res =>
           res.status mustBe 200
         }
 

--- a/it/controllers/RemovePackagingDetailsConfirmationControllerIntegrationSpec.scala
+++ b/it/controllers/RemovePackagingDetailsConfirmationControllerIntegrationSpec.scala
@@ -22,7 +22,7 @@ class RemovePackagingDetailsConfirmationControllerIntegrationSpec extends Specif
       given
         .commonPrecondition
 
-      WsTestClient.withClient { client ⇒
+      WsTestClient.withClient { client =>
         val result1 = client.url(s"$baseUrl/remove-packaging-site-details/$ref")
           .withFollowRedirects(false)
           .addCookies(DefaultWSCookie("mdtp", authAndSessionCookie))

--- a/it/controllers/RemoveSmallProducerConfirmControllerIntegrationSpec.scala
+++ b/it/controllers/RemoveSmallProducerConfirmControllerIntegrationSpec.scala
@@ -27,7 +27,7 @@ class RemoveSmallProducerConfirmControllerIntegrationSpec extends Specifications
       given
       .commonPrecondition
 
-      WsTestClient.withClient { client ⇒
+      WsTestClient.withClient { client =>
         val result1 = client.url(s"$baseUrl/remove-small-producer-confirm/$sdilRefPartyDrinks")
           .withFollowRedirects(false)
           .addCookies(DefaultWSCookie("mdtp", authAndSessionCookie))

--- a/test-utils/helpers/LoggerHelper.scala
+++ b/test-utils/helpers/LoggerHelper.scala
@@ -23,15 +23,15 @@ import play.api.LoggerLike
 import scala.jdk.CollectionConverters.CollectionHasAsScala
 
 trait LoggerHelper {
-  def withCaptureOfLoggingFrom(
-                                logger: LoggerLike
-                              )(body: (=> List[ILoggingEvent]) => Unit) {
+  protected def withCaptureOfLoggingFrom(
+                                          logger: LoggerLike
+                                        )(body: (=> List[ILoggingEvent]) => Unit): Unit = {
     withCaptureOfLoggingFrom(logger.logger.asInstanceOf[LogbackLogger])(body)
   }
 
   def withCaptureOfLoggingFrom(
                                 logger: LogbackLogger
-                              )(body: (=> List[ILoggingEvent]) => Unit) {
+                              )(body: (=> List[ILoggingEvent]) => Unit): Unit = {
     val appender = new ListAppender[ILoggingEvent]()
     appender.setContext(logger.getLoggerContext)
     appender.start()

--- a/test/controllers/CheckYourAnswersControllerSpec.scala
+++ b/test/controllers/CheckYourAnswersControllerSpec.scala
@@ -70,7 +70,7 @@ class CheckYourAnswersControllerSpec extends SpecBase with SummaryListFluency wi
       val expectedPreHeader = s"${aSubscription.orgName} - ${Messages("firstQuarter")} 2022"
 
       running(application) {
-        val request = FakeRequest(GET, routes.CheckYourAnswersController.onPageLoad.url)
+        val request = FakeRequest(GET, routes.CheckYourAnswersController.onPageLoad().url)
         val result = route(application, request).value
 
         status(result) mustEqual OK
@@ -88,7 +88,7 @@ class CheckYourAnswersControllerSpec extends SpecBase with SummaryListFluency wi
         bind[SoftDrinksIndustryLevyConnector].toInstance(mockSdilConnector)).build()
       val expectedPreHeader = s"${aSubscription.orgName} - ${Messages("secondQuarter")} 2021"
       running(application) {
-        val request = FakeRequest(GET, routes.CheckYourAnswersController.onPageLoad.url)
+        val request = FakeRequest(GET, routes.CheckYourAnswersController.onPageLoad().url)
         val result = route(application, request).value
 
         status(result) mustEqual OK
@@ -107,7 +107,7 @@ class CheckYourAnswersControllerSpec extends SpecBase with SummaryListFluency wi
         bind[SoftDrinksIndustryLevyConnector].toInstance(mockSdilConnector)).build()
       val expectedPreHeader = s"${aSubscription.orgName} - ${Messages("thirdQuarter")} 2020"
       running(application) {
-        val request = FakeRequest(GET, routes.CheckYourAnswersController.onPageLoad.url)
+        val request = FakeRequest(GET, routes.CheckYourAnswersController.onPageLoad().url)
         val result = route(application, request).value
 
         status(result) mustEqual OK
@@ -126,7 +126,7 @@ class CheckYourAnswersControllerSpec extends SpecBase with SummaryListFluency wi
         bind[SoftDrinksIndustryLevyConnector].toInstance(mockSdilConnector)).build()
       val expectedPreHeader = s"${aSubscription.orgName} - ${Messages("fourthQuarter")} 2019"
       running(application) {
-        val request = FakeRequest(GET, routes.CheckYourAnswersController.onPageLoad.url)
+        val request = FakeRequest(GET, routes.CheckYourAnswersController.onPageLoad().url)
         val result = route(application, request).value
 
         status(result) mustEqual OK
@@ -144,7 +144,7 @@ class CheckYourAnswersControllerSpec extends SpecBase with SummaryListFluency wi
         bind[SDILSessionCache].toInstance(mockSDILSessionCache),
         bind[SoftDrinksIndustryLevyConnector].toInstance(mockSdilConnector)).build()
       val result = running(application) {
-        val request = FakeRequest(GET, routes.CheckYourAnswersController.onPageLoad.url)
+        val request = FakeRequest(GET, routes.CheckYourAnswersController.onPageLoad().url)
         route(application, request).value
       }
 
@@ -163,7 +163,7 @@ class CheckYourAnswersControllerSpec extends SpecBase with SummaryListFluency wi
         bind[SDILSessionCache].toInstance(mockSDILSessionCache),
         bind[SoftDrinksIndustryLevyConnector].toInstance(mockSdilConnector)).build()
       running(application) {
-        val request = FakeRequest(GET, routes.CheckYourAnswersController.onPageLoad.url)
+        val request = FakeRequest(GET, routes.CheckYourAnswersController.onPageLoad().url)
         val result = route(application, request).value
 
         status(result) mustEqual OK
@@ -191,7 +191,7 @@ class CheckYourAnswersControllerSpec extends SpecBase with SummaryListFluency wi
         bind[SoftDrinksIndustryLevyConnector].toInstance(mockSdilConnector)).build()
 
       running(application) {
-        val request = FakeRequest(GET, routes.CheckYourAnswersController.onPageLoad.url)
+        val request = FakeRequest(GET, routes.CheckYourAnswersController.onPageLoad().url)
         val result = route(application, request).value
 
         status(result) mustEqual OK
@@ -232,7 +232,7 @@ class CheckYourAnswersControllerSpec extends SpecBase with SummaryListFluency wi
         bind[SoftDrinksIndustryLevyConnector].toInstance(mockSdilConnector)).build()
 
       running(application) {
-        val request = FakeRequest(GET, routes.CheckYourAnswersController.onPageLoad.url)
+        val request = FakeRequest(GET, routes.CheckYourAnswersController.onPageLoad().url)
         val result = route(application, request).value
 
         status(result) mustEqual OK
@@ -255,7 +255,7 @@ class CheckYourAnswersControllerSpec extends SpecBase with SummaryListFluency wi
         bind[SDILSessionCache].toInstance(mockSDILSessionCache),
         bind[SoftDrinksIndustryLevyConnector].toInstance(mockSdilConnector)).build()
       running(application) {
-        val request = FakeRequest(GET, routes.CheckYourAnswersController.onPageLoad.url)
+        val request = FakeRequest(GET, routes.CheckYourAnswersController.onPageLoad().url)
         val result = route(application, request).value
 
         status(result) mustEqual OK
@@ -280,7 +280,7 @@ class CheckYourAnswersControllerSpec extends SpecBase with SummaryListFluency wi
         bind[SoftDrinksIndustryLevyConnector].toInstance(mockSdilConnector)
       ).build()
       running(application) {
-        val request = FakeRequest(GET, routes.CheckYourAnswersController.onPageLoad.url)
+        val request = FakeRequest(GET, routes.CheckYourAnswersController.onPageLoad().url)
         val result = route(application, request).value
 
         status(result) mustEqual OK
@@ -316,7 +316,7 @@ class CheckYourAnswersControllerSpec extends SpecBase with SummaryListFluency wi
         bind[SDILSessionCache].toInstance(mockSDILSessionCache),
         bind[SoftDrinksIndustryLevyConnector].toInstance(mockSdilConnector)).build()
       running(application) {
-        val request = FakeRequest(GET, routes.CheckYourAnswersController.onPageLoad.url)
+        val request = FakeRequest(GET, routes.CheckYourAnswersController.onPageLoad().url)
         val result = route(application, request).value
 
         status(result) mustEqual OK
@@ -347,7 +347,7 @@ class CheckYourAnswersControllerSpec extends SpecBase with SummaryListFluency wi
         bind[SDILSessionCache].toInstance(mockSDILSessionCache),
         bind[SoftDrinksIndustryLevyConnector].toInstance(mockSdilConnector)).build()
       running(application) {
-        val request = FakeRequest(GET, routes.CheckYourAnswersController.onPageLoad.url)
+        val request = FakeRequest(GET, routes.CheckYourAnswersController.onPageLoad().url)
         val result = route(application, request).value
 
         status(result) mustEqual OK
@@ -383,7 +383,7 @@ class CheckYourAnswersControllerSpec extends SpecBase with SummaryListFluency wi
         bind[SDILSessionCache].toInstance(mockSDILSessionCache),
         bind[SoftDrinksIndustryLevyConnector].toInstance(mockSdilConnector)).build()
       running(application) {
-        val request = FakeRequest(GET, routes.CheckYourAnswersController.onPageLoad.url)
+        val request = FakeRequest(GET, routes.CheckYourAnswersController.onPageLoad().url)
         val result = route(application, request).value
 
         status(result) mustEqual OK
@@ -407,7 +407,7 @@ class CheckYourAnswersControllerSpec extends SpecBase with SummaryListFluency wi
         bind[SDILSessionCache].toInstance(mockSDILSessionCache),
         bind[SoftDrinksIndustryLevyConnector].toInstance(mockSdilConnector)).build()
       running(application) {
-        val request = FakeRequest(GET, routes.CheckYourAnswersController.onPageLoad.url)
+        val request = FakeRequest(GET, routes.CheckYourAnswersController.onPageLoad().url)
         val result = route(application, request).value
 
         status(result) mustEqual OK
@@ -443,7 +443,7 @@ class CheckYourAnswersControllerSpec extends SpecBase with SummaryListFluency wi
         bind[SDILSessionCache].toInstance(mockSDILSessionCache),
         bind[SoftDrinksIndustryLevyConnector].toInstance(mockSdilConnector)).build()
       running(application) {
-        val request = FakeRequest(GET, routes.CheckYourAnswersController.onPageLoad.url)
+        val request = FakeRequest(GET, routes.CheckYourAnswersController.onPageLoad().url)
         val result = route(application, request).value
 
         status(result) mustEqual OK
@@ -467,7 +467,7 @@ class CheckYourAnswersControllerSpec extends SpecBase with SummaryListFluency wi
         bind[SDILSessionCache].toInstance(mockSDILSessionCache),
         bind[SoftDrinksIndustryLevyConnector].toInstance(mockSdilConnector)).build()
       running(application) {
-        val request = FakeRequest(GET, routes.CheckYourAnswersController.onPageLoad.url)
+        val request = FakeRequest(GET, routes.CheckYourAnswersController.onPageLoad().url)
         val result = route(application, request).value
 
         status(result) mustEqual OK
@@ -503,7 +503,7 @@ class CheckYourAnswersControllerSpec extends SpecBase with SummaryListFluency wi
         bind[SDILSessionCache].toInstance(mockSDILSessionCache),
         bind[SoftDrinksIndustryLevyConnector].toInstance(mockSdilConnector)).build()
       running(application) {
-        val request = FakeRequest(GET, routes.CheckYourAnswersController.onPageLoad.url)
+        val request = FakeRequest(GET, routes.CheckYourAnswersController.onPageLoad().url)
         val result = route(application, request).value
 
         status(result) mustEqual OK
@@ -527,7 +527,7 @@ class CheckYourAnswersControllerSpec extends SpecBase with SummaryListFluency wi
         bind[SDILSessionCache].toInstance(mockSDILSessionCache),
         bind[SoftDrinksIndustryLevyConnector].toInstance(mockSdilConnector)).build()
       running(application) {
-        val request = FakeRequest(GET, routes.CheckYourAnswersController.onPageLoad.url)
+        val request = FakeRequest(GET, routes.CheckYourAnswersController.onPageLoad().url)
         val result = route(application, request).value
 
         status(result) mustEqual OK
@@ -563,7 +563,7 @@ class CheckYourAnswersControllerSpec extends SpecBase with SummaryListFluency wi
         bind[SDILSessionCache].toInstance(mockSDILSessionCache),
         bind[SoftDrinksIndustryLevyConnector].toInstance(mockSdilConnector)).build()
       running(application) {
-        val request = FakeRequest(GET, routes.CheckYourAnswersController.onPageLoad.url)
+        val request = FakeRequest(GET, routes.CheckYourAnswersController.onPageLoad().url)
         val result = route(application, request).value
 
         status(result) mustEqual OK
@@ -587,7 +587,7 @@ class CheckYourAnswersControllerSpec extends SpecBase with SummaryListFluency wi
         bind[SDILSessionCache].toInstance(mockSDILSessionCache),
         bind[SoftDrinksIndustryLevyConnector].toInstance(mockSdilConnector)).build()
       running(application) {
-        val request = FakeRequest(GET, routes.CheckYourAnswersController.onPageLoad.url)
+        val request = FakeRequest(GET, routes.CheckYourAnswersController.onPageLoad().url)
         val result = route(application, request).value
 
         status(result) mustEqual OK
@@ -644,7 +644,7 @@ class CheckYourAnswersControllerSpec extends SpecBase with SummaryListFluency wi
         bind[SDILSessionCache].toInstance(mockSDILSessionCache),
         bind[SoftDrinksIndustryLevyConnector].toInstance(mockSdilConnector)).build()
       running(application) {
-        val request = FakeRequest(GET, routes.CheckYourAnswersController.onPageLoad.url)
+        val request = FakeRequest(GET, routes.CheckYourAnswersController.onPageLoad().url)
         val result = route(application, request).value
 
         status(result) mustEqual OK
@@ -692,7 +692,7 @@ class CheckYourAnswersControllerSpec extends SpecBase with SummaryListFluency wi
         bind[SDILSessionCache].toInstance(mockSDILSessionCache),
         bind[SoftDrinksIndustryLevyConnector].toInstance(mockSdilConnector)).build()
       running(application) {
-        val request = FakeRequest(GET, routes.CheckYourAnswersController.onPageLoad.url)
+        val request = FakeRequest(GET, routes.CheckYourAnswersController.onPageLoad().url)
         val result = route(application, request).value
 
         status(result) mustEqual OK
@@ -739,7 +739,7 @@ class CheckYourAnswersControllerSpec extends SpecBase with SummaryListFluency wi
         bind[SDILSessionCache].toInstance(mockSDILSessionCache),
         bind[SoftDrinksIndustryLevyConnector].toInstance(mockSdilConnector)).build()
       running(application) {
-        val request = FakeRequest(GET, routes.CheckYourAnswersController.onPageLoad.url)
+        val request = FakeRequest(GET, routes.CheckYourAnswersController.onPageLoad().url)
         val result = route(application, request).value
 
         status(result) mustEqual OK
@@ -769,7 +769,7 @@ class CheckYourAnswersControllerSpec extends SpecBase with SummaryListFluency wi
         bind[SDILSessionCache].toInstance(mockSDILSessionCache),
         bind[SoftDrinksIndustryLevyConnector].toInstance(mockSdilConnector)).build()
       running(application) {
-        val request = FakeRequest(GET, routes.CheckYourAnswersController.onPageLoad.url)
+        val request = FakeRequest(GET, routes.CheckYourAnswersController.onPageLoad().url)
         val result = route(application, request).value
 
         status(result) mustEqual OK
@@ -815,7 +815,7 @@ class CheckYourAnswersControllerSpec extends SpecBase with SummaryListFluency wi
         bind[SDILSessionCache].toInstance(mockSDILSessionCache),
         bind[SoftDrinksIndustryLevyConnector].toInstance(mockSdilConnector)).build()
       running(application) {
-        val request = FakeRequest(GET, routes.CheckYourAnswersController.onPageLoad.url)
+        val request = FakeRequest(GET, routes.CheckYourAnswersController.onPageLoad().url)
         val result = route(application, request).value
 
         status(result) mustEqual OK
@@ -867,7 +867,7 @@ class CheckYourAnswersControllerSpec extends SpecBase with SummaryListFluency wi
         bind[SDILSessionCache].toInstance(mockSDILSessionCache),
         bind[SoftDrinksIndustryLevyConnector].toInstance(mockSdilConnector)).build()
       running(application) {
-        val request = FakeRequest(GET, routes.CheckYourAnswersController.onPageLoad.url)
+        val request = FakeRequest(GET, routes.CheckYourAnswersController.onPageLoad().url)
         val result = route(application, request).value
 
         status(result) mustEqual OK
@@ -919,7 +919,7 @@ class CheckYourAnswersControllerSpec extends SpecBase with SummaryListFluency wi
         bind[SDILSessionCache].toInstance(mockSDILSessionCache),
         bind[SoftDrinksIndustryLevyConnector].toInstance(mockSdilConnector)).build()
       running(application) {
-        val request = FakeRequest(GET, routes.CheckYourAnswersController.onPageLoad.url)
+        val request = FakeRequest(GET, routes.CheckYourAnswersController.onPageLoad().url)
         val result = route(application, request).value
 
         status(result) mustEqual OK
@@ -971,7 +971,7 @@ class CheckYourAnswersControllerSpec extends SpecBase with SummaryListFluency wi
         bind[SDILSessionCache].toInstance(mockSDILSessionCache),
         bind[SoftDrinksIndustryLevyConnector].toInstance(mockSdilConnector)).build()
       running(application) {
-        val request = FakeRequest(GET, routes.CheckYourAnswersController.onPageLoad.url)
+        val request = FakeRequest(GET, routes.CheckYourAnswersController.onPageLoad().url)
         val result = route(application, request).value
 
         status(result) mustEqual OK
@@ -1024,7 +1024,7 @@ class CheckYourAnswersControllerSpec extends SpecBase with SummaryListFluency wi
         bind[SDILSessionCache].toInstance(mockSDILSessionCache),
         bind[SoftDrinksIndustryLevyConnector].toInstance(mockSdilConnector)).build()
       running(application) {
-        val request = FakeRequest(GET, routes.CheckYourAnswersController.onPageLoad.url)
+        val request = FakeRequest(GET, routes.CheckYourAnswersController.onPageLoad().url)
         val result = route(application, request).value
 
         status(result) mustEqual OK
@@ -1051,7 +1051,7 @@ class CheckYourAnswersControllerSpec extends SpecBase with SummaryListFluency wi
         bind[SDILSessionCache].toInstance(mockSDILSessionCache),
         bind[SoftDrinksIndustryLevyConnector].toInstance(mockSdilConnector)).build()
       running(application) {
-        val request = FakeRequest(GET, routes.CheckYourAnswersController.onPageLoad.url)
+        val request = FakeRequest(GET, routes.CheckYourAnswersController.onPageLoad().url)
         val result = route(application, request).value
 
         status(result) mustEqual OK
@@ -1070,7 +1070,7 @@ class CheckYourAnswersControllerSpec extends SpecBase with SummaryListFluency wi
         bind[SDILSessionCache].toInstance(mockSDILSessionCache),
         bind[SoftDrinksIndustryLevyConnector].toInstance(mockSdilConnector)).build()
       running(application) {
-        val request = FakeRequest(GET, routes.CheckYourAnswersController.onPageLoad.url)
+        val request = FakeRequest(GET, routes.CheckYourAnswersController.onPageLoad().url)
         val result = route(application, request).value
 
         status(result) mustEqual OK
@@ -1106,7 +1106,7 @@ class CheckYourAnswersControllerSpec extends SpecBase with SummaryListFluency wi
         bind[SDILSessionCache].toInstance(mockSDILSessionCache),
         bind[SoftDrinksIndustryLevyConnector].toInstance(mockSdilConnector)).build()
       val result = running(application) {
-        val request = FakeRequest(GET, routes.CheckYourAnswersController.onPageLoad.url)
+        val request = FakeRequest(GET, routes.CheckYourAnswersController.onPageLoad().url)
         route(application, request).value
       }
 
@@ -1124,7 +1124,7 @@ class CheckYourAnswersControllerSpec extends SpecBase with SummaryListFluency wi
         bind[SoftDrinksIndustryLevyConnector].toInstance(mockSdilConnector)).build()
 
       running(application) {
-        val request = FakeRequest(GET, routes.CheckYourAnswersController.onPageLoad.url)
+        val request = FakeRequest(GET, routes.CheckYourAnswersController.onPageLoad().url)
         val result = route(application, request).value
 
         status(result) mustEqual OK
@@ -1141,7 +1141,7 @@ class CheckYourAnswersControllerSpec extends SpecBase with SummaryListFluency wi
         bind[SoftDrinksIndustryLevyConnector].toInstance(mockSdilConnector)).build()
 
       val result = running(application) {
-        val request = FakeRequest(GET, routes.CheckYourAnswersController.onPageLoad.url)
+        val request = FakeRequest(GET, routes.CheckYourAnswersController.onPageLoad().url)
         route(application, request).value
       }
 
@@ -1160,7 +1160,7 @@ class CheckYourAnswersControllerSpec extends SpecBase with SummaryListFluency wi
         bind[SoftDrinksIndustryLevyConnector].toInstance(mockSdilConnector)).build()
 
       val result = running(application) {
-        val request = FakeRequest(GET, routes.CheckYourAnswersController.onPageLoad.url)
+        val request = FakeRequest(GET, routes.CheckYourAnswersController.onPageLoad().url)
         route(application, request).value
       }
 
@@ -1178,7 +1178,7 @@ class CheckYourAnswersControllerSpec extends SpecBase with SummaryListFluency wi
         bind[SoftDrinksIndustryLevyConnector].toInstance(mockSdilConnector)).build()
 
       val result = running(application) {
-        val request = FakeRequest(GET, routes.CheckYourAnswersController.onPageLoad.url)
+        val request = FakeRequest(GET, routes.CheckYourAnswersController.onPageLoad().url)
         route(application, request).value
       }
 
@@ -1215,7 +1215,7 @@ class CheckYourAnswersControllerSpec extends SpecBase with SummaryListFluency wi
         bind[SDILSessionCache].toInstance(mockSDILSessionCache),
         bind[SoftDrinksIndustryLevyConnector].toInstance(mockSdilConnector)).build()
       running(application) {
-        val request = FakeRequest(GET, routes.CheckYourAnswersController.onPageLoad.url)
+        val request = FakeRequest(GET, routes.CheckYourAnswersController.onPageLoad().url)
         val result = route(application, request).value
 
         status(result) mustEqual OK

--- a/test/controllers/IndexControllerSpec.scala
+++ b/test/controllers/IndexControllerSpec.scala
@@ -30,7 +30,7 @@ class IndexControllerSpec extends SpecBase {
       val application = applicationBuilder(userAnswers = None).build()
 
       running(application) {
-        val request = FakeRequest(GET, routes.IndexController.onPageLoad.url)
+        val request = FakeRequest(GET, routes.IndexController.onPageLoad().url)
 
         val result = route(application, request).value
 

--- a/test/controllers/UnauthorisedControllerSpec.scala
+++ b/test/controllers/UnauthorisedControllerSpec.scala
@@ -30,7 +30,7 @@ class UnauthorisedControllerSpec extends SpecBase {
       val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
 
       running(application) {
-        val request = FakeRequest(GET, routes.UnauthorisedController.onPageLoad.url)
+        val request = FakeRequest(GET, routes.UnauthorisedController.onPageLoad().url)
 
         val result = route(application, request).value
 

--- a/test/controllers/actions/AuthActionSpec.scala
+++ b/test/controllers/actions/AuthActionSpec.scala
@@ -98,7 +98,7 @@ class AuthActionSpec extends SpecBase {
           val result = controller.onPageLoad()(FakeRequest())
 
           status(result) mustBe SEE_OTHER
-          redirectLocation(result).value mustBe routes.UnauthorisedController.onPageLoad.url
+          redirectLocation(result).value mustBe routes.UnauthorisedController.onPageLoad().url
         }
       }
     }
@@ -119,7 +119,7 @@ class AuthActionSpec extends SpecBase {
           val result = controller.onPageLoad()(FakeRequest())
 
           status(result) mustBe SEE_OTHER
-          redirectLocation(result).value mustBe routes.UnauthorisedController.onPageLoad.url
+          redirectLocation(result).value mustBe routes.UnauthorisedController.onPageLoad().url
         }
       }
     }
@@ -140,7 +140,7 @@ class AuthActionSpec extends SpecBase {
           val result = controller.onPageLoad()(FakeRequest())
 
           status(result) mustBe SEE_OTHER
-          redirectLocation(result).value mustBe routes.UnauthorisedController.onPageLoad.url
+          redirectLocation(result).value mustBe routes.UnauthorisedController.onPageLoad().url
         }
       }
     }
@@ -161,7 +161,7 @@ class AuthActionSpec extends SpecBase {
           val result = controller.onPageLoad()(FakeRequest())
 
           status(result) mustBe SEE_OTHER
-          redirectLocation(result) mustBe Some(routes.UnauthorisedController.onPageLoad.url)
+          redirectLocation(result) mustBe Some(routes.UnauthorisedController.onPageLoad().url)
         }
       }
     }
@@ -182,7 +182,7 @@ class AuthActionSpec extends SpecBase {
           val result = controller.onPageLoad()(FakeRequest())
 
           status(result) mustBe SEE_OTHER
-          redirectLocation(result) mustBe Some(routes.UnauthorisedController.onPageLoad.url)
+          redirectLocation(result) mustBe Some(routes.UnauthorisedController.onPageLoad().url)
         }
       }
     }


### PR DESCRIPTION
Non-exhaustive match update completed on package.scala file. 
Unable to update non-exhaustive match on ukAddress.

Also updated files to remove depreciations. 
Currently 0 warnings for both Tests & ITs.
Currently 0 warnings within code
