### PR TITLE
DLS-8073 update secondary warehouse details summary to not have edit link

### DIFF
--- a/app/viewmodels/checkAnswers/SecondaryWarehouseDetailsSummary.scala
+++ b/app/viewmodels/checkAnswers/SecondaryWarehouseDetailsSummary.scala
@@ -58,8 +58,6 @@ object SecondaryWarehouseDetailsSummary  {
           key     = Key(HtmlContent(AddressFormattingHelper.addressFormatting(warehouse._2.address, warehouse._2.tradingName))),
           classes = "govuk-!-font-weight-regular govuk-!-width-two-thirds",
           actions = Some(Actions("",Seq(
-            ActionItemViewModel("site.edit", routes.IndexController.onPageLoad().url)
-              .withVisuallyHiddenText(messages("secondaryWarehouseDetails.edit.hidden")),
             ActionItemViewModel("site.remove", routes.RemoveWarehouseConfirmController.onPageLoad(warehouse._1).url)
               .withVisuallyHiddenText(messages("secondaryWarehouseDetails.remove.hidden"))
           )))

--- a/test/controllers/SecondaryWarehouseDetailsControllerSpec.scala
+++ b/test/controllers/SecondaryWarehouseDetailsControllerSpec.scala
@@ -116,7 +116,7 @@ class SecondaryWarehouseDetailsControllerSpec extends SpecBase with MockitoSugar
         summaryListContents.first.text() must include ("ABC Ltd")
         summaryListContents.last.text() must include ("Super Cola Ltd")
 
-        val summaryActions = doc(contentAsString(result)).getElementsByClass("govuk-summary-list__actions-list")
+        val summaryActions = doc(contentAsString(result)).getElementsByClass("govuk-summary-list__actions")
         summaryActions.size() mustEqual 2
         summaryActions.first.text() must include("Remove")
         summaryActions.last.text() must include("Remove")


### PR DESCRIPTION
tests passing.  No changes to UIs noted.  Screenshot in ticket. 