### PR TITLE
Removed todos in own brands

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,15 +5,18 @@
 The Soft Drinks Industry Levy (SDIL) digital service is split into a number of different microservices all serving specific functions which are listed below:
 
 **Liability tool** - Standalone frontend service that is used to check a company's liability in regards to the levy.
-
+**Registration Frontend** - The initial subscription registration service.
 **Returns Frontend** - The returns journey frontend for the service.
-
+**Variations Frontend** - Service to submit variations on registration and returns functionalities.
+**Accounts Frontend** - Dashboard functionality service.
 **Backend** - The service that the frontend uses to call HOD APIs to retrieve and send information relating to business information and subscribing to the levy.
-
 **Stub** - Microservice that is used to mimic the DES APIs when running services locally or in the development and staging environments.
-
 For details about the sugar tax see [the GOV.UK guidance](https://www.gov.uk/guidance/soft-drinks-industry-levy)
 
+## Feature switches
+**addressLookupFrontendTest.enabled** switches between  our stub endpoints and real ALF
+**defaultReturnTest.enabled** defaults return for testing purposes so users do not have to navigate from dashboard
+**balanceAll.enabled** use balance history / balance in final calculation
 ## Running from source
 Clone the repository using SSH:
 

--- a/app/config/FrontendAppConfig.scala
+++ b/app/config/FrontendAppConfig.scala
@@ -58,7 +58,7 @@ class FrontendAppConfig @Inject() (servicesConfig: ServicesConfig, configuration
 
   val balanceAllEnabled: Boolean = servicesConfig.getBoolean("balanceAll.enabled")
   val addressLookUpFrontendTestEnabled: Boolean = servicesConfig.getBoolean("addressLookupFrontendTest.enabled")
-
+  val defaultReturnSetup: Boolean = servicesConfig.getBoolean("defaultReturnTest.enabled")
   val softDrinksIndustryLevyFrontendLink :String  = s"${servicesConfig.baseUrl("soft-drinks-industry-levy-frontend")}/soft-drinks-industry-levy/register/start"
   val addressLookupService: String  = servicesConfig.baseUrl("address-lookup-frontend")
 

--- a/app/orchestrators/ReturnsOrchestrator.scala
+++ b/app/orchestrators/ReturnsOrchestrator.scala
@@ -20,7 +20,7 @@ import cats.data.EitherT
 import cats.implicits._
 import com.google.inject.{Inject, Singleton}
 import errors.{NoPendingReturnForGivenPeriod, ReturnsErrors}
-import models.requests.{DataRequest, IdentifierRequest, OptionalDataRequest}
+import models.requests.{DataRequest, IdentifierRequest}
 import models.{Amounts, ReturnPeriod, UserAnswers}
 import play.api.mvc.AnyContent
 import repositories.{SDILSessionCache, SDILSessionKeys, SessionRepository}
@@ -35,11 +35,9 @@ class ReturnsOrchestrator @Inject()(returnService: ReturnService,
                                     sdilSessionCache: SDILSessionCache,
                                     sessionRepository: SessionRepository) {
 
-
-  //ToDo remove when ATs etc route through the dashboard
-  def tempSetupReturn
-                     (implicit request: OptionalDataRequest[AnyContent], hc: HeaderCarrier, ec: ExecutionContext): ReturnResult[Unit] = {
-    val latestReturn = returnService.getPendingReturns(request.subscription.utr).map{pendingReturns =>
+  def tempSetupReturnTest
+                     (implicit request: IdentifierRequest[AnyContent], hc: HeaderCarrier, ec: ExecutionContext): ReturnResult[Unit] = {
+    lazy val latestReturn = returnService.getPendingReturns(request.subscription.utr).map{pendingReturns =>
       pendingReturns.sortBy(_.start).headOption match {
         case Some(pendingReturn) => Right(pendingReturn)
         case _ => Left(NoPendingReturnForGivenPeriod)
@@ -50,6 +48,7 @@ class ReturnsOrchestrator @Inject()(returnService: ReturnService,
       _ <- setupUserAnswers(request.sdilEnrolment, false)
     } yield ((): Unit)
   }
+
   def setupNewReturn(year: Int, quarter: Int, nilReturn: Boolean)
                     (implicit request: IdentifierRequest[AnyContent], hc: HeaderCarrier, ec: ExecutionContext): ReturnResult[Unit] = {
     for {

--- a/build.sbt
+++ b/build.sbt
@@ -35,7 +35,7 @@ lazy val root = (project in file("."))
     PlayKeys.playDefaultPort := 8703,
     ScoverageKeys.coverageExcludedFiles := "<empty>;Reverse.*;.*handlers.*;.*components.*;" +
       ".*Routes.*;.*viewmodels.govuk.*;",
-    ScoverageKeys.coverageMinimumStmtTotal := 86,
+    ScoverageKeys.coverageMinimumStmtTotal := 87,
     ScoverageKeys.coverageFailOnMinimum := true,
     ScoverageKeys.coverageHighlighting := true,
         scalacOptions ++= Seq(

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -139,6 +139,7 @@ higherBandCostPerLitre = "0.24"
 
 balanceAll.enabled = false
 addressLookupFrontendTest.enabled = true
+defaultReturnTest.enabled = true
 
 address-lookup-frontend-init-config {
        version = 2

--- a/it/controllers/testSupport/TestConfiguration.scala
+++ b/it/controllers/testSupport/TestConfiguration.scala
@@ -122,7 +122,8 @@ trait TestConfiguration
     "json.encryption.key" -> "fqpLDZ4sumDsekHkeEBlCA==",
     "json.encryption.previousKeys" -> "[]",
     "play.http.router" -> "testOnlyDoNotUseInAppConf.Routes",
-    "addressLookupFrontendTest.enabled" -> "false"
+    "addressLookupFrontendTest.enabled" -> "false",
+    "defaultReturnTest.enabled" -> "false"
   )
 
   override implicit lazy val app: Application = appBuilder().build()

--- a/test/controllers/OwnBrandsControllerSpec.scala
+++ b/test/controllers/OwnBrandsControllerSpec.scala
@@ -27,6 +27,7 @@ import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{times, verify, when}
 import org.scalatestplus.mockito.MockitoSugar
+import pages.OwnBrandsPage
 import play.api.inject.bind
 import play.api.libs.json.Writes
 import play.api.mvc.Call
@@ -79,24 +80,24 @@ class OwnBrandsControllerSpec extends SpecBase with MockitoSugar with LoggerHelp
       }
     }
 
-    //ToDo uncomment when using real code for own brands page
-//    "must populate the view correctly on a GET when the question has previously been answered" in {
-//
-//      val userAnswers = UserAnswers(sdilNumber).set(OwnBrandsPage, true).success.value
-//
-//      val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
-//
-//      running(application) {
-//        val request = FakeRequest(GET, ownBrandsRoute)
-//
-//        val view = application.injector.instanceOf[OwnBrandsView]
-//
-//        val result = route(application, request).value
-//
-//        status(result) mustEqual OK
-//        contentAsString(result) mustEqual view(form.fill(true), NormalMode)(request, messages(application)).toString
-//      }
-//    }
+
+    "must populate the view correctly on a GET when the question has previously been answered" in {
+
+      val userAnswers = UserAnswers(sdilNumber).set(OwnBrandsPage, true).success.value
+
+      val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
+
+      running(application) {
+        val request = FakeRequest(GET, ownBrandsRoute)
+
+        val view = application.injector.instanceOf[OwnBrandsView]
+
+        val result = route(application, request).value
+
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual view(form.fill(true), NormalMode)(request, messages(application)).toString
+      }
+    }
 
     "must redirect to the next page when valid data is submitted" in {
 

--- a/test/resources/application.conf
+++ b/test/resources/application.conf
@@ -15,6 +15,7 @@
 play.filters.disabled += "play.filters.csrf.CSRFFilter"
 
 play.http.secret.key = "some_secret"
+defaultReturnTest.enabled = false
 
 mongo-async-driver {
   akka {


### PR DESCRIPTION
Added in "TEST RETURN" into returns controller, feature switched, removed the own brands logic which could have gone into production. this passes ui tests as is.

please also merge in these 2 app configs 
https://github.com/hmrc/app-config-base/pull/8779
https://github.com/hmrc/app-config-production/pull/18599