### PR TITLE
DLS-8269: add extra logging for address connector

### DIFF
--- a/app/connectors/AddressLookupConnector.scala
+++ b/app/connectors/AddressLookupConnector.scala
@@ -22,15 +22,18 @@ import connectors.httpParsers.ResponseHttpParser.HttpResult
 import models.alf.AlfResponse
 import models.alf.init.JourneyConfig
 import uk.gov.hmrc.http.{HeaderCarrier, HttpClient}
+import utilitlies.GenericLogger
 
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class AddressLookupConnector @Inject()(val http: HttpClient,
+                                       val genericLogger: GenericLogger,
                                        implicit val config: FrontendAppConfig) {
   private[connectors] def getAddressUrl(id: String, addressLookupFrontendTestEnabled: Boolean): String = {
     if(addressLookupFrontendTestEnabled) {
+      genericLogger.logger.info(s"AddressLookupConnector.getAddressUrl configured host is ${config.host}")
       s"${config.host}${controllers.test.routes.AddressFrontendStubController.addresses(id).url}"
     } else {
       s"${config.addressLookupService}/api/confirmed?id=$id"
@@ -38,6 +41,8 @@ class AddressLookupConnector @Inject()(val http: HttpClient,
   }
   private[connectors] def initJourneyUrl(addressLookupFrontendTestEnabled: Boolean): String = {
     if(addressLookupFrontendTestEnabled) {
+      genericLogger.logger.info(s"AddressLookupConnector.initJourneyUrl configured host is ${config.host}\n and " +
+        s"configured test url is ${controllers.test.routes.AddressFrontendStubController.initialise().url}")
       s"${config.host}${controllers.test.routes.AddressFrontendStubController.initialise().url}"
     } else {
       s"${config.addressLookupService}/api/init"

--- a/test/connectors/AddressLookupConnectorSpec.scala
+++ b/test/connectors/AddressLookupConnectorSpec.scala
@@ -20,22 +20,26 @@ import base.ReturnsTestData._
 import base.SpecBase
 import connectors.httpParsers.AddressLookupHttpParser.AddressLookupInitJourneyReads
 import connectors.httpParsers.ResponseHttpParser.HttpResult
+import helpers.LoggerHelper
 import mocks.MockHttp
 import models.alf.AlfResponse
 import models.alf.init.{JourneyConfig, JourneyOptions}
 import models.core.ErrorModel
 import org.scalatestplus.mockito.MockitoSugar
+import play.api.Logger
 import play.api.http.Status
 import play.api.test.Helpers.{await, defaultAwaitTimeout}
 import play.mvc.Http.HeaderNames
 import uk.gov.hmrc.http.HttpResponse
+import utilitlies.GenericLogger
 
 import scala.concurrent.Future
 
 class AddressLookupConnectorSpec extends SpecBase with MockitoSugar with MockHttp {
 
   val errorModel: HttpResponse = HttpResponse(Status.BAD_REQUEST, "Error Message")
-  val testAddressLookupConnector = new AddressLookupConnector(mockHttp, frontendAppConfig)
+
+  val testAddressLookupConnector = new AddressLookupConnector(mockHttp, new GenericLogger,frontendAppConfig)
 
   lazy val id = "111111111"
 


### PR DESCRIPTION
A temp logging to debug the staging ALF issue. This will be reverted after.