### PR TITLE
DLS-8628: fix navigation from packaging sites

### DIFF
--- a/app/config/FrontendAppConfig.scala
+++ b/app/config/FrontendAppConfig.scala
@@ -19,6 +19,7 @@ package config
 
 import com.google.inject.{Inject, Singleton}
 import com.typesafe.config.Config
+import models.Mode
 import play.api.Configuration
 import play.api.mvc.RequestHeader
 import uk.gov.hmrc.play.bootstrap.binders.SafeRedirectUrl
@@ -81,8 +82,8 @@ class FrontendAppConfig @Inject() (servicesConfig: ServicesConfig, configuration
     }
 
     object PackingDetails {
-      def offRampUrl(sdilId: String): String = {
-        s"$addressLookupOffRampUrl${controllers.addressLookupFrontend.routes.RampOffController.packingSiteDetailsOffRamp(sdilId, "").url.replace("?id=", "")}"
+      def offRampUrl(sdilId: String, mode: Mode): String = {
+        s"$addressLookupOffRampUrl${controllers.addressLookupFrontend.routes.RampOffController.packingSiteDetailsOffRamp(sdilId, "", mode).url.replace("?id=", "")}"
       }
     }
   }

--- a/app/controllers/PackAtBusinessAddressController.scala
+++ b/app/controllers/PackAtBusinessAddressController.scala
@@ -88,10 +88,10 @@ class PackAtBusinessAddressController @Inject()(
                         closureDate = None
                       )
                 )), PackAtBusinessAddressPage).flatMap(_ =>
-                  Future.successful(routes.PackagingSiteDetailsController.onPageLoad(NormalMode).url))
+                  Future.successful(routes.PackagingSiteDetailsController.onPageLoad(mode).url))
               } else {
                 updateDatabaseWithoutRedirect(updatedAnswers, PackAtBusinessAddressPage).flatMap(_ =>
-                  addressLookupService.initJourneyAndReturnOnRampUrl(PackingDetails))
+                  addressLookupService.initJourneyAndReturnOnRampUrl(PackingDetails, mode = mode))
               }
           } yield {
             Redirect(onwardUrl)

--- a/app/controllers/PackagingSiteDetailsController.scala
+++ b/app/controllers/PackagingSiteDetailsController.scala
@@ -79,12 +79,12 @@ class PackagingSiteDetailsController @Inject()(
             onwardUrl:String <-
               if(value){
                 updateDatabaseWithoutRedirect(updatedAnswers, PackagingSiteDetailsPage).flatMap(_ =>
-                addressLookupService.initJourneyAndReturnOnRampUrl(PackingDetails))
+                addressLookupService.initJourneyAndReturnOnRampUrl(PackingDetails, mode = mode))
               } else {
                 updateDatabaseWithoutRedirect(updatedAnswers, PackagingSiteDetailsPage).flatMap(_ =>
                   (Some(SdilReturn.apply(updatedAnswers)), Some(request.subscription)) match {
                     case (Some(sdilReturn), Some(subscription)) =>
-                      if (UserTypeCheck.isNewImporter (sdilReturn, subscription) ) {
+                      if (UserTypeCheck.isNewImporter (sdilReturn, subscription) && mode == NormalMode) {
                         Future.successful(routes.AskSecondaryWarehouseInReturnController.onPageLoad(NormalMode).url)
                       } else {
                         Future.successful(routes.CheckYourAnswersController.onPageLoad.url)

--- a/app/controllers/addressLookupFrontend/RampOffController.scala
+++ b/app/controllers/addressLookupFrontend/RampOffController.scala
@@ -17,7 +17,7 @@
 package controllers.addressLookupFrontend
 
 import controllers.actions.{DataRequiredAction, DataRetrievalAction, IdentifierAction}
-import models.NormalMode
+import models.{Mode, NormalMode}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import repositories.SessionRepository
 import services.{AddressLookupService, PackingDetails, WarehouseDetails}
@@ -45,14 +45,14 @@ class RampOffController @Inject()(           identify: IdentifierAction,
     }
   }
 
-  def packingSiteDetailsOffRamp(sdilId: String, alfId: String): Action[AnyContent] = (identify andThen getData andThen requireData).async {
+  def packingSiteDetailsOffRamp(sdilId: String, alfId: String, mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData).async {
     implicit request =>
       for {
         alfResponse         <- addressLookupService.getAddress(alfId)
         updatedUserAnswers = addressLookupService.addAddressUserAnswers(PackingDetails, alfResponse.address, request.userAnswers, sdilId, alfId)
         _                   <- sessionRepository.set(updatedUserAnswers)
       } yield {
-        Redirect(controllers.routes.PackagingSiteDetailsController.onPageLoad(NormalMode))
+        Redirect(controllers.routes.PackagingSiteDetailsController.onPageLoad(mode))
       }
   }
 }

--- a/app/navigation/Navigator.scala
+++ b/app/navigation/Navigator.scala
@@ -74,6 +74,7 @@ class Navigator @Inject()() {
     case HowManyCreditsForExportPage => _ => routes.CheckYourAnswersController.onPageLoad
     case ClaimCreditsForLostDamagedPage => userAnswers => checkClaimCreditsForLostDamagedPageNavigation(userAnswers)
     case HowManyCreditsForLostDamagedPage => _ => routes.CheckYourAnswersController.onPageLoad
+    case RemovePackagingDetailsConfirmationPage => _ => routes.PackagingSiteDetailsController.onPageLoad(CheckMode)
     case _ => _ => routes.CheckYourAnswersController.onPageLoad
   }
 

--- a/app/views/PackagingSiteDetailsView.scala.html
+++ b/app/views/PackagingSiteDetailsView.scala.html
@@ -40,7 +40,7 @@
         <h1 class="govuk-heading-l">@messages("packagingSiteDetails.title.heading", siteList.size, if(siteList.size == 1) "" else "s")</h1>
         <p class="govuk-body-m">@messages("packagingSiteDetails.info")</p>
 
-        @govukSummaryList(PackagingSiteDetailsSummary.summaryList(siteList))
+        @govukSummaryList(PackagingSiteDetailsSummary.summaryList(siteList, mode))
 
         @govukRadios(
             RadiosViewModel.yesNo(

--- a/app/views/RemovePackagingDetailsConfirmationView.scala.html
+++ b/app/views/RemovePackagingDetailsConfirmationView.scala.html
@@ -27,7 +27,7 @@
 @layout(pageTitle = title(form, messages("removePackagingDetailsConfirmation.title"))) {
 
 
-    @formHelper(action = routes.RemovePackagingDetailsConfirmationController.onSubmit(ref = addressRef), Symbol("autoComplete") -> "off") {
+    @formHelper(action = routes.RemovePackagingDetailsConfirmationController.onSubmit(mode, ref = addressRef), Symbol("autoComplete") -> "off") {
 
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form))

--- a/app/views/helpers/returnDetails/PackAtBusinessAddressSummary.scala
+++ b/app/views/helpers/returnDetails/PackAtBusinessAddressSummary.scala
@@ -46,7 +46,7 @@ object PackAtBusinessAddressSummary {
                 actions =
                   if (isCheckAnswers) {
                     Seq(
-                      ActionItemViewModel("site.change", routes.PackAtBusinessAddressController.onPageLoad(CheckMode).url)
+                      ActionItemViewModel("site.change", routes.PackagingSiteDetailsController.onPageLoad(CheckMode).url)
                         .withAttribute(("id", "change-packaging-sites"))
                         .withVisuallyHiddenText(messages("checkYourAnswers.sites.packing.change.hidden"))
                     )

--- a/app/views/helpers/returnDetails/PackagingSiteDetailsSummary.scala
+++ b/app/views/helpers/returnDetails/PackagingSiteDetailsSummary.scala
@@ -17,6 +17,7 @@
 package views.helpers.returnDetails
 
 import controllers.routes
+import models.{Mode, NormalMode}
 import models.backend.Site
 import play.api.i18n.Messages
 import uk.gov.hmrc.govukfrontend.views.Aliases.{Actions, SummaryList}
@@ -28,13 +29,13 @@ import viewmodels.implicits._
 
 object PackagingSiteDetailsSummary {
 
-  def summaryList(packagingSiteList: Map[String, Site])(implicit messages: Messages): SummaryList = {
+  def summaryList(packagingSiteList: Map[String, Site], mode: Mode)(implicit messages: Messages): SummaryList = {
     SummaryListViewModel(
-      rows = row2(packagingSiteList)
+      rows = row2(packagingSiteList, mode)
     )
   }
 
-  def row2(packagingSiteList: Map[String, Site])(implicit messages: Messages): List[SummaryListRow] = {
+  def row2(packagingSiteList: Map[String, Site], mode: Mode = NormalMode)(implicit messages: Messages): List[SummaryListRow] = {
     packagingSiteList.map {
       site =>
         SummaryListRow(
@@ -45,7 +46,7 @@ object PackagingSiteDetailsSummary {
           ),
           actions = if (packagingSiteList.size > 1) {
             Some(Actions("", Seq(
-              ActionItemViewModel("site.remove", routes.RemovePackagingDetailsConfirmationController.onPageLoad(site._1).url)
+              ActionItemViewModel("site.remove", routes.RemovePackagingDetailsConfirmationController.onPageLoad(mode, site._1).url)
                 .withVisuallyHiddenText(messages("packagingSiteDetails.hidden"))
             )))
           } else {

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -131,13 +131,14 @@ POST       /change-packaging-site-details                       controllers.Pack
 GET        /submit-return/year/:year/quarter/:quarter/nil-return/:nilReturn  controllers.ReturnsController.onPageLoad(year: Int, quarter: Int, nilReturn: Boolean)
 GET        /return-sent                                         controllers.ReturnSentController.onPageLoad
 
-
 GET        /remove-warehouse-details/:index                     controllers.RemoveWarehouseConfirmController.onPageLoad(mode: Mode = NormalMode, index: String)
 POST       /remove-warehouse-details/:index                     controllers.RemoveWarehouseConfirmController.onSubmit(mode: Mode = NormalMode, index: String)
 
 GET        /remove-packaging-site-details/:ref                  controllers.RemovePackagingDetailsConfirmationController.onPageLoad(mode: Mode = NormalMode, ref: String)
 POST       /remove-packaging-site-details/:ref                  controllers.RemovePackagingDetailsConfirmationController.onSubmit(mode: Mode = NormalMode, ref: String)
-
+GET        /change-remove-packaging-site-details/:ref           controllers.RemovePackagingDetailsConfirmationController.onPageLoad(mode: Mode = CheckMode, ref: String)
+POST       /change-remove-packaging-site-details/:ref           controllers.RemovePackagingDetailsConfirmationController.onSubmit(mode: Mode = CheckMode, ref: String)
 
 GET       /off-ramp/secondary-warehouses/:sdilId                controllers.addressLookupFrontend.RampOffController.secondaryWareHouseDetailsOffRamp(sdilId: String, id: String)
-GET       /off-ramp/packing-site-details/:sdilId                controllers.addressLookupFrontend.RampOffController.packingSiteDetailsOffRamp(sdilId: String, id: String)
+GET       /off-ramp/packing-site-details/:sdilId                controllers.addressLookupFrontend.RampOffController.packingSiteDetailsOffRamp(sdilId: String, id: String, mode: Mode = NormalMode)
+GET       /off-ramp/change-packing-site-details/:sdilId         controllers.addressLookupFrontend.RampOffController.packingSiteDetailsOffRamp(sdilId: String, id: String, mode: Mode = CheckMode)

--- a/it/services/AddressLookupServiceIntegrationSpec.scala
+++ b/it/services/AddressLookupServiceIntegrationSpec.scala
@@ -2,6 +2,7 @@ package services
 
 import controllers.testSupport.helpers.ALFTestHelper
 import controllers.testSupport.{ITCoreTestData, Specifications, TestConfiguration}
+import models.NormalMode
 import models.alf.init.{JourneyConfig, JourneyOptions}
 import models.alf.{AlfAddress, AlfResponse}
 import models.core.ErrorModel
@@ -78,7 +79,7 @@ class AddressLookupServiceIntegrationSpec extends Specifications with TestConfig
     s"return ramp on url when success for $PackingDetails" in {
       val req = FakeRequest()
       val sdilId: String = "bar"
-      val journeyConfig = service.createJourneyConfig(PackingDetails, sdilId)(req, messages)
+      val journeyConfig = service.createJourneyConfig(PackingDetails, sdilId, NormalMode)(req, messages)
       given.alf.getSuccessResponseFromALFInit(locationHeaderReturned = "foo")
 
       whenReady(service.initJourneyAndReturnOnRampUrl(PackingDetails)(implicitly,implicitly, messages, req)) { result =>
@@ -89,7 +90,7 @@ class AddressLookupServiceIntegrationSpec extends Specifications with TestConfig
     s"return ramp on url when success for $WarehouseDetails" in {
       val req = FakeRequest()
       val sdilId: String = "bar"
-      val journeyConfig = service.createJourneyConfig(WarehouseDetails, sdilId)(req, messages)
+      val journeyConfig = service.createJourneyConfig(WarehouseDetails, sdilId, NormalMode)(req, messages)
       given.alf.getSuccessResponseFromALFInit(locationHeaderReturned = "foo")
 
       whenReady(service.initJourneyAndReturnOnRampUrl(WarehouseDetails)(implicitly,implicitly, messages, req)) { result =>
@@ -100,7 +101,7 @@ class AddressLookupServiceIntegrationSpec extends Specifications with TestConfig
     "throw exception when fail" in {
       val req = FakeRequest()
       val sdilId: String = "bar"
-      val journeyConfig = service.createJourneyConfig(PackingDetails, sdilId)(req, messages)
+      val journeyConfig = service.createJourneyConfig(PackingDetails, sdilId, NormalMode)(req, messages)
       given.alf.getFailResponseFromALFInit(Status.INTERNAL_SERVER_ERROR)
 
       intercept[Exception](await(service.initJourneyAndReturnOnRampUrl(PackingDetails)(implicitly,implicitly, messages, req)))

--- a/test/controllers/AskSecondaryWarehouseInReturnControllerSpec.scala
+++ b/test/controllers/AskSecondaryWarehouseInReturnControllerSpec.scala
@@ -117,7 +117,7 @@ class AskSecondaryWarehouseInReturnControllerSpec extends SpecBase with MockitoS
 
       when(mockSessionRepository.set(any())) thenReturn Future.successful(Right(true))
       when(mockAddressLookupService.initJourneyAndReturnOnRampUrl(
-        ArgumentMatchers.eq(WarehouseDetails), ArgumentMatchers.any())(
+        ArgumentMatchers.eq(WarehouseDetails), ArgumentMatchers.any(), ArgumentMatchers.any())(
         ArgumentMatchers.any(), ArgumentMatchers.any(),ArgumentMatchers.any(), ArgumentMatchers.any()))
         .thenReturn(Future.successful(onwardUrlForALF))
 
@@ -141,7 +141,7 @@ class AskSecondaryWarehouseInReturnControllerSpec extends SpecBase with MockitoS
         redirectLocation(result).value mustEqual onwardUrlForALF
 
         verify(mockAddressLookupService, times(1)).initJourneyAndReturnOnRampUrl(
-          ArgumentMatchers.eq(WarehouseDetails), ArgumentMatchers.any())(
+          ArgumentMatchers.eq(WarehouseDetails), ArgumentMatchers.any(), ArgumentMatchers.any())(
           ArgumentMatchers.any(), ArgumentMatchers.any(),ArgumentMatchers.any(), ArgumentMatchers.any())
       }
     }
@@ -153,7 +153,7 @@ class AskSecondaryWarehouseInReturnControllerSpec extends SpecBase with MockitoS
 
       when(mockSessionRepository.set(any())) thenReturn Future.successful(Right(true))
       when(mockAddressLookupService.initJourneyAndReturnOnRampUrl(
-        ArgumentMatchers.eq(WarehouseDetails), ArgumentMatchers.any())(
+        ArgumentMatchers.eq(WarehouseDetails), ArgumentMatchers.any(), ArgumentMatchers.any())(
         ArgumentMatchers.any(), ArgumentMatchers.any(),ArgumentMatchers.any(), ArgumentMatchers.any()))
         .thenReturn(Future.successful(onwardUrlForALF))
 
@@ -178,7 +178,7 @@ class AskSecondaryWarehouseInReturnControllerSpec extends SpecBase with MockitoS
         redirectLocation(result).value mustEqual routes.CheckYourAnswersController.onPageLoad.url
 
         verify(mockAddressLookupService, times(0)).initJourneyAndReturnOnRampUrl(
-          ArgumentMatchers.eq(WarehouseDetails), ArgumentMatchers.any())(
+          ArgumentMatchers.eq(WarehouseDetails), ArgumentMatchers.any(), ArgumentMatchers.any())(
           ArgumentMatchers.any(), ArgumentMatchers.any(),ArgumentMatchers.any(), ArgumentMatchers.any())
       }
     }
@@ -188,7 +188,7 @@ class AskSecondaryWarehouseInReturnControllerSpec extends SpecBase with MockitoS
       when(mockSessionRepository.set(any())) thenReturn Future.successful(Right(true))
 
       when(mockAddressLookupService.initJourneyAndReturnOnRampUrl(
-        ArgumentMatchers.eq(WarehouseDetails), ArgumentMatchers.any())(
+        ArgumentMatchers.eq(WarehouseDetails), ArgumentMatchers.any(), ArgumentMatchers.any())(
         ArgumentMatchers.any(), ArgumentMatchers.any(),ArgumentMatchers.any(), ArgumentMatchers.any()))
         .thenReturn(Future.failed(new Exception("uh oh spaghetio")))
 
@@ -210,7 +210,7 @@ class AskSecondaryWarehouseInReturnControllerSpec extends SpecBase with MockitoS
 
 
         verify(mockAddressLookupService, times(1)).initJourneyAndReturnOnRampUrl(
-          ArgumentMatchers.eq(WarehouseDetails), ArgumentMatchers.any())(
+          ArgumentMatchers.eq(WarehouseDetails), ArgumentMatchers.any(), ArgumentMatchers.any())(
           ArgumentMatchers.any(), ArgumentMatchers.any(),ArgumentMatchers.any(), ArgumentMatchers.any())
       }
     }

--- a/test/controllers/PackAtBusinessAddressControllerSpec.scala
+++ b/test/controllers/PackAtBusinessAddressControllerSpec.scala
@@ -139,10 +139,9 @@ class PackAtBusinessAddressControllerSpec extends SpecBase with MockitoSugar wit
       val mockAddressLookupService = mock[AddressLookupService]
       val onwardUrlForALF = "foobarwizz"
 
-
       when(mockSessionRepository.set(any())) thenReturn Future.successful(Right(true))
       when(mockAddressLookupService.initJourneyAndReturnOnRampUrl(
-        ArgumentMatchers.eq(PackingDetails), ArgumentMatchers.any())(
+        ArgumentMatchers.eq(PackingDetails), ArgumentMatchers.any(), ArgumentMatchers.any())(
         ArgumentMatchers.any(), ArgumentMatchers.any(),ArgumentMatchers.any(), ArgumentMatchers.any()))
         .thenReturn(Future.successful(onwardUrlForALF))
 
@@ -166,7 +165,7 @@ class PackAtBusinessAddressControllerSpec extends SpecBase with MockitoSugar wit
         redirectLocation(result).value mustEqual onwardUrlForALF
 
         verify(mockAddressLookupService, times(1)).initJourneyAndReturnOnRampUrl(
-          ArgumentMatchers.eq(PackingDetails), ArgumentMatchers.any())(
+          ArgumentMatchers.eq(PackingDetails), ArgumentMatchers.any(), ArgumentMatchers.any())(
           ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any())
       }
     }

--- a/test/controllers/SecondaryWarehouseDetailsControllerSpec.scala
+++ b/test/controllers/SecondaryWarehouseDetailsControllerSpec.scala
@@ -225,7 +225,7 @@ class SecondaryWarehouseDetailsControllerSpec extends SpecBase with MockitoSugar
       when(mockSessionRepository.set(any())) thenReturn Future.successful(Right(true))
 
       when(mockAddressLookupService.initJourneyAndReturnOnRampUrl(
-        ArgumentMatchers.eq(WarehouseDetails), ArgumentMatchers.any())(
+        ArgumentMatchers.eq(WarehouseDetails), ArgumentMatchers.any(), ArgumentMatchers.any())(
         ArgumentMatchers.any(), ArgumentMatchers.any(),ArgumentMatchers.any(), ArgumentMatchers.any()))
         .thenReturn(Future.successful(onwardUrlForALF))
 
@@ -249,7 +249,7 @@ class SecondaryWarehouseDetailsControllerSpec extends SpecBase with MockitoSugar
         redirectLocation(result).value mustEqual onwardUrlForALF
 
         verify(mockAddressLookupService, times(1)).initJourneyAndReturnOnRampUrl(
-          ArgumentMatchers.eq(WarehouseDetails), ArgumentMatchers.any())(
+          ArgumentMatchers.eq(WarehouseDetails), ArgumentMatchers.any(), ArgumentMatchers.any())(
           ArgumentMatchers.any(), ArgumentMatchers.any(),ArgumentMatchers.any(), ArgumentMatchers.any())
       }
     }
@@ -278,7 +278,7 @@ class SecondaryWarehouseDetailsControllerSpec extends SpecBase with MockitoSugar
         redirectLocation(result).value mustEqual controllers.routes.CheckYourAnswersController.onPageLoad.url
 
         verify(mockAddressLookupService, times(0)).initJourneyAndReturnOnRampUrl(
-          ArgumentMatchers.any(), ArgumentMatchers.any())(
+          ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any())(
           ArgumentMatchers.any(), ArgumentMatchers.any(),ArgumentMatchers.any(), ArgumentMatchers.any())
       }
     }
@@ -288,7 +288,7 @@ class SecondaryWarehouseDetailsControllerSpec extends SpecBase with MockitoSugar
       when(mockSessionRepository.set(any())) thenReturn Future.successful(Right(true))
 
       when(mockAddressLookupService.initJourneyAndReturnOnRampUrl(
-        ArgumentMatchers.eq(WarehouseDetails), ArgumentMatchers.any())(
+        ArgumentMatchers.eq(WarehouseDetails), ArgumentMatchers.any(), ArgumentMatchers.any())(
         ArgumentMatchers.any(), ArgumentMatchers.any(),ArgumentMatchers.any(), ArgumentMatchers.any()))
         .thenReturn(Future.failed(new Exception("uh oh spaghetio")))
 
@@ -310,7 +310,7 @@ class SecondaryWarehouseDetailsControllerSpec extends SpecBase with MockitoSugar
 
 
         verify(mockAddressLookupService, times(1)).initJourneyAndReturnOnRampUrl(
-          ArgumentMatchers.eq(WarehouseDetails), ArgumentMatchers.any())(
+          ArgumentMatchers.eq(WarehouseDetails), ArgumentMatchers.any(), ArgumentMatchers.any())(
           ArgumentMatchers.any(), ArgumentMatchers.any(),ArgumentMatchers.any(), ArgumentMatchers.any())
       }
     }

--- a/test/controllers/addressLookupFrontend/RampOffControllerSpec.scala
+++ b/test/controllers/addressLookupFrontend/RampOffControllerSpec.scala
@@ -187,7 +187,7 @@ class RampOffControllerSpec extends SpecBase with MockitoSugar {
         .thenReturn(Future.successful(Right(true)))
 
       running(application) {
-        val request = FakeRequest(GET, routes.RampOffController.packingSiteDetailsOffRamp(sdilId, alfId).url)
+        val request = FakeRequest(GET, routes.RampOffController.packingSiteDetailsOffRamp(sdilId, alfId, NormalMode).url)
 
         val result = route(application, request).value
         status(result) mustBe SEE_OTHER
@@ -208,7 +208,7 @@ class RampOffControllerSpec extends SpecBase with MockitoSugar {
         .thenReturn(Future.failed(new Exception("woopsie")))
 
       running(application) {
-        val request = FakeRequest(GET, routes.RampOffController.packingSiteDetailsOffRamp(sdilId, alfId).url)
+        val request = FakeRequest(GET, routes.RampOffController.packingSiteDetailsOffRamp(sdilId, alfId, NormalMode).url)
 
         intercept[Exception](await(route(application, request).value))
       }
@@ -235,7 +235,7 @@ class RampOffControllerSpec extends SpecBase with MockitoSugar {
         .thenThrow(new RuntimeException("foo"))
 
       running(application) {
-        val request = FakeRequest(GET, routes.RampOffController.packingSiteDetailsOffRamp(sdilId, alfId).url)
+        val request = FakeRequest(GET, routes.RampOffController.packingSiteDetailsOffRamp(sdilId, alfId, NormalMode).url)
 
         intercept[Exception](await(route(application, request).value))
       }
@@ -265,7 +265,7 @@ class RampOffControllerSpec extends SpecBase with MockitoSugar {
         .thenReturn(Future.failed(new Exception("woopsie")))
 
       running(application) {
-        val request = FakeRequest(GET, routes.RampOffController.packingSiteDetailsOffRamp(sdilId, alfId).url)
+        val request = FakeRequest(GET, routes.RampOffController.packingSiteDetailsOffRamp(sdilId, alfId, NormalMode).url)
         intercept[Exception](await(route(application, request).value))
       }
     }

--- a/test/pages/PackagingSiteDetailsPageSpec.scala
+++ b/test/pages/PackagingSiteDetailsPageSpec.scala
@@ -35,7 +35,7 @@ import views.helpers.returnDetails.PackagingSiteDetailsSummary
 import views.html.PackagingSiteDetailsView
 
 
-class packagingSiteDetailsPageSpec extends SpecBase with MockitoSugar with SummaryListFluency with PageBehaviours {
+class PackagingSiteDetailsPageSpec extends SpecBase with MockitoSugar with SummaryListFluency with PageBehaviours {
 
   val form = new PackagingSiteDetailsFormProvider()
   val view: PackagingSiteDetailsView = application.injector.instanceOf[PackagingSiteDetailsView]

--- a/test/pages/RemovePackagingDetailsConfirmationPageSpec.scala
+++ b/test/pages/RemovePackagingDetailsConfirmationPageSpec.scala
@@ -51,7 +51,7 @@ class RemovePackagingDetailsConfirmationPageSpec extends ViewSpecHelper with Pag
       result.getElementsByClass("govuk-radios__item").last().text() mustBe "No"
       result.getElementsByTag("button").first().text() mustBe "Continue"
       result.getElementsByClass("govuk-back-link").text() mustBe "Back"
-      result.getElementsByTag("form").first().attr("action") mustBe controllers.routes.RemovePackagingDetailsConfirmationController.onSubmit("foo").url
+      result.getElementsByTag("form").first().attr("action") mustBe controllers.routes.RemovePackagingDetailsConfirmationController.onSubmit(NormalMode,"foo").url
     }
 
     "display correctly with form errors" in {
@@ -65,7 +65,7 @@ class RemovePackagingDetailsConfirmationPageSpec extends ViewSpecHelper with Pag
       result.getElementsByClass("govuk-radios__item").last().text() mustBe "No"
       result.getElementsByTag("button").first().text() mustBe "Continue"
       result.getElementsByClass("govuk-back-link").text() mustBe "Back"
-      result.getElementsByTag("form").first().attr("action") mustBe controllers.routes.RemovePackagingDetailsConfirmationController.onSubmit("foo").url
+      result.getElementsByTag("form").first().attr("action") mustBe controllers.routes.RemovePackagingDetailsConfirmationController.onSubmit(NormalMode, "foo").url
       result.getElementsByClass("govuk-error-summary__title").text() mustBe "There is a problem"
       result.getElementById("value-error").text() mustBe "Error: Select yes if you want to remove this packaging site"
     }

--- a/test/services/AddressLookupServiceSpec.scala
+++ b/test/services/AddressLookupServiceSpec.scala
@@ -20,7 +20,7 @@ import base.ReturnsTestData._
 import base.SpecBase
 import connectors.AddressLookupConnector
 import controllers.routes
-import models.Warehouse
+import models.{NormalMode, Warehouse}
 import models.alf.AlfAddress
 import models.alf.init._
 import models.backend.{Site, UkAddress}
@@ -401,7 +401,7 @@ class AddressLookupServiceSpec extends SpecBase with FutureAwaits with DefaultAw
     s"should return a journey config for $WarehouseDetails" in {
       val request = FakeRequest("foo","bar")
       val exampleSdilIdWeGenerate: String = "wizz"
-      val res = service.createJourneyConfig(WarehouseDetails, exampleSdilIdWeGenerate)(request, implicitly)
+      val res = service.createJourneyConfig(WarehouseDetails, exampleSdilIdWeGenerate, NormalMode)(request, implicitly)
       val expected =  JourneyConfig(
         version = 2,
         options = JourneyOptions(

--- a/test/viewmodels/PackagingSiteDetailsSummarySpec.scala
+++ b/test/viewmodels/PackagingSiteDetailsSummarySpec.scala
@@ -18,6 +18,7 @@ package viewmodels
 
 import base.ReturnsTestData._
 import base.SpecBase
+import models.NormalMode
 import models.backend.{Site, UkAddress}
 import uk.gov.hmrc.govukfrontend.views.viewmodels.content._
 import views.helpers.returnDetails.PackagingSiteDetailsSummary
@@ -101,11 +102,11 @@ class PackagingSiteDetailsSummarySpec extends SpecBase {
       val packagingSiteSummaryRowList = PackagingSiteDetailsSummary.row2(Map("ref1" -> site1, "ref2" -> site2))
       packagingSiteSummaryRowList.head.key.content.asHtml.toString() mustBe "trade2<br>foo2, bar2, wizz2"
       packagingSiteSummaryRowList.head.actions.toList.head.items.last.content.asHtml.toString() mustBe "Remove"
-      packagingSiteSummaryRowList.head.actions.toList.head.items.last.href mustBe controllers.routes.RemovePackagingDetailsConfirmationController.onPageLoad("ref1").url
+      packagingSiteSummaryRowList.head.actions.toList.head.items.last.href mustBe controllers.routes.RemovePackagingDetailsConfirmationController.onPageLoad(NormalMode,"ref1").url
 
       packagingSiteSummaryRowList.last.key.content.asHtml.toString() mustBe "trade<br>foo, bar, wizz"
       packagingSiteSummaryRowList.last.actions.toList.head.items.last.content.asHtml.toString() mustBe "Remove"
-      packagingSiteSummaryRowList.last.actions.toList.head.items.last.href mustBe controllers.routes.RemovePackagingDetailsConfirmationController.onPageLoad("ref2").url
+      packagingSiteSummaryRowList.last.actions.toList.head.items.last.href mustBe controllers.routes.RemovePackagingDetailsConfirmationController.onPageLoad(NormalMode,"ref2").url
     }
   }
 

--- a/test/views/ReturnDetailsExpectedResults.scala
+++ b/test/views/ReturnDetailsExpectedResults.scala
@@ -61,7 +61,7 @@ trait ReturnDetailsExpectedResults {
     SummaryHeadingIds.broughtIntoTheUKFromSmallProducers -> "/change-brought-into-uk-from-small-producers",
     SummaryHeadingIds.exported -> "/change-claim-credits-for-exports",
     SummaryHeadingIds.lostOrDestroyed -> "/change-claim-credits-for-lost-damaged",
-    SummaryHeadingIds.registeredSites -> "/change-pack-at-business-address-in-return"
+    SummaryHeadingIds.registeredSites -> "/change-packaging-site-details",
   )
 
   val returnDetailsSummaryListsWithActionHrefsForLitres = Map(


### PR DESCRIPTION
DLS-8628: fix navigation

DLS-8628: Set logging level to INFO

DLS-8628: add tests check mode in packaging site details

DLS-8628: Set logging level to INFO

DLS-8628: add change remove packing site confirmation

DLS-8628: reset config

DLS-8628: fix remove navigation

DLS-8628: fix redirection to packing site details page

DLS-8628: fix broken navigation tests from CYA

DLS-8628: log level to info

DLS-8628: default mode as NormalMode

DLS-8628: add check mode tests to remove packaging site details