### PR TITLE
DLS-8628: add condition for navigating to pack at business address

### DIFF
--- a/app/controllers/actions/RequiredUserAnswers.scala
+++ b/app/controllers/actions/RequiredUserAnswers.scala
@@ -57,7 +57,7 @@ class RequiredUserAnswers @Inject()(genericLogger: GenericLogger)(implicit val e
             !previousPageAnswer.contains(previousPage.previousPageAnswerRequired)
         case (false, _) => false
         case _ => true
-        }
+      }
     }
   }
   private[controllers] def smallProducerCheck(subscription: RetrievedSubscription): List[RequiredPage[_, _,_]] = {
@@ -97,7 +97,7 @@ class RequiredUserAnswers @Inject()(genericLogger: GenericLogger)(implicit val e
   }
 
   private[controllers] val packingListReturnChange: DataRequest[_] => List[RequiredPage[_, _,_]] = { (request: DataRequest[_]) =>
-    if(UserTypeCheck.isNewPacker(SdilReturn.apply(request.userAnswers), request.subscription)) {
+    if(UserTypeCheck.isNewPacker(SdilReturn.apply(request.userAnswers), request.subscription) && request.subscription.productionSites.isEmpty) {
       List(RequiredPage(PackAtBusinessAddressPage, None)(implicitly[Reads[Boolean]]))
     } else {
       List.empty

--- a/app/navigation/Navigator.scala
+++ b/app/navigation/Navigator.scala
@@ -283,7 +283,7 @@ class Navigator @Inject()() {
                                                      subscriptionOpt: Option[RetrievedSubscription]) = {
     (sdilReturnOpt, subscriptionOpt) match {
       case (Some(sdilReturn), Some(subscription)) =>
-        if (UserTypeCheck.isNewPacker(sdilReturn,subscription)) {
+        if (UserTypeCheck.isNewPacker(sdilReturn,subscription) && subscription.productionSites.isEmpty) {
           routes.PackAtBusinessAddressController.onPageLoad(NormalMode)
         } else {
           routes.AskSecondaryWarehouseInReturnController.onPageLoad(NormalMode)

--- a/test/navigation/NavigatorSpec.scala
+++ b/test/navigation/NavigatorSpec.scala
@@ -591,7 +591,7 @@ class NavigatorSpec extends SpecBase with LoggerHelper {
               "when meets the pack conditions and import conditions for being a new packer and new importer" in {
                 val sdilActivity = RetrievedActivity(smallProducer = false, largeProducer = true, contractPacker = false,
                   importer = false, voluntaryRegistration = false)
-                val modifiedSubscription = aSubscription.copy(activity = sdilActivity)
+                val modifiedSubscription = aSubscription.copy(activity = sdilActivity, productionSites = List.empty)
                 val sdilReturn = SdilReturn((0L, 0L), (1L, 1L), List(SmallProducer("", "", (1L, 1L))), (1L, 1L), (1L, 1L), (0L, 0L), (0L, 0L))
                 val result = navigate(emptyUserAnswers, Some(sdilReturn), Some(modifiedSubscription))
                 result mustBe routes.PackAtBusinessAddressController.onPageLoad(NormalMode)


### PR DESCRIPTION
DLS-8628: add production sites to user answers

DLS-8628: fix broken navigation test

DLS-8628: fix required page for pack at business address issue

DLS-8628: update tests

DLS-8628: clean up

DLS-8628: use subscription production sites for required page logic

DLS-8628: add missing test scenario for return change