### PR TITLE
DLS-8683: remove packaging sites when on cya and no longer new packer

### DIFF
--- a/app/controllers/CheckYourAnswersController.scala
+++ b/app/controllers/CheckYourAnswersController.scala
@@ -19,12 +19,16 @@ package controllers
 import com.google.inject.Inject
 import config.FrontendAppConfig
 import controllers.actions._
+import handlers.ErrorHandler
+import models.retrieved.RetrievedSubscription
+import models.{SdilReturn, UserAnswers}
+import navigation.Navigator
 import orchestrators.ReturnsOrchestrator
 import pages.CheckYourAnswersPage
-import play.api.i18n.{I18nSupport, MessagesApi}
+import play.api.i18n.MessagesApi
 import play.api.mvc.{Action, AnyContent, Call, MessagesControllerComponents}
-import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
-import utilitlies.GenericLogger
+import repositories.SessionRepository
+import utilitlies.{GenericLogger, UserTypeCheck}
 import views.html.CheckYourAnswersView
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -32,6 +36,9 @@ import scala.concurrent.{ExecutionContext, Future}
 class CheckYourAnswersController @Inject()(
                                             override val messagesApi: MessagesApi,
                                             val config: FrontendAppConfig,
+                                            val sessionRepository: SessionRepository,
+                                            val navigator: Navigator,
+                                            val errorHandler: ErrorHandler,
                                             val genericLogger: GenericLogger,
                                             identify: IdentifierAction,
                                             getData: DataRetrievalAction,
@@ -41,30 +48,30 @@ class CheckYourAnswersController @Inject()(
                                             val controllerComponents: MessagesControllerComponents,
                                             checkYourAnswersView: CheckYourAnswersView,
                                             returnsOrchestrator: ReturnsOrchestrator
-                                          ) (implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport {
-
+                                          ) (implicit ec: ExecutionContext) extends ControllerHelper {
 
   def onPageLoad: Action[AnyContent] = (identify andThen getData andThen requireData andThen checkReturnSubmission).async {
     implicit request =>
       requiredUserAnswers.requireData(CheckYourAnswersPage) {
         val sdilRef = request.sdilEnrolment
         val returnPeriod = request.returnPeriod
-        val userAnswers = request.userAnswers
         val isSmallProducer = request.subscription.activity.smallProducer
 
-        returnsOrchestrator.calculateAmounts(sdilRef, userAnswers, returnPeriod).map { amounts =>
-          val submitUrl: Call = routes.CheckYourAnswersController.onSubmit
-          Ok(checkYourAnswersView(request.subscription.orgName,
-            returnPeriod,
-            userAnswers,
-            amounts,
-            submitUrl,
-            isSmallProducer
-          )(implicitly, implicitly, config))
-        }.recoverWith {
-          case t: Throwable =>
-            genericLogger.logger.error(s"Exception occurred while retrieving SDIL data for $sdilRef", t)
-            Future.successful(Redirect(routes.JourneyRecoveryController.onPageLoad()))
+        sanitiseUserAnswers(request.userAnswers, request.subscription).flatMap { userAnswers =>
+          returnsOrchestrator.calculateAmounts(sdilRef, userAnswers, returnPeriod).map { amounts =>
+            val submitUrl: Call = routes.CheckYourAnswersController.onSubmit
+            Ok(checkYourAnswersView(request.subscription.orgName,
+              returnPeriod,
+              userAnswers,
+              amounts,
+              submitUrl,
+              isSmallProducer
+            )(implicitly, implicitly, config))
+          }.recoverWith {
+            case t: Throwable =>
+              genericLogger.logger.error(s"Exception occurred while retrieving SDIL data for $sdilRef", t)
+              Future.successful(Redirect(routes.JourneyRecoveryController.onPageLoad()))
+          }
         }
       }
   }
@@ -76,5 +83,30 @@ class CheckYourAnswersController @Inject()(
           Redirect(routes.ReturnSentController.onPageLoad)
         }
       }
+  }
+
+  private def sanitiseUserAnswers(answers: UserAnswers, subscription: RetrievedSubscription) = {
+    val sanitisedPackingSitesUserAnswers = sanitisePackingSitesInAnswers(answers, subscription)
+    val sanitisedAnswers = sanitiseWarehousesInAnswers(sanitisedPackingSitesUserAnswers, subscription)
+
+    updateDatabaseWithoutRedirect(sanitisedAnswers,CheckYourAnswersPage).map { _ =>
+      sanitisedAnswers
+    }
+  }
+
+  private def sanitisePackingSitesInAnswers(answers: UserAnswers, subscription: RetrievedSubscription) = {
+    if (!UserTypeCheck.isNewPacker(SdilReturn.apply(answers), subscription)) {
+      answers.copy(packagingSiteList = Map.empty)
+    } else {
+      answers
+    }
+  }
+
+  private def sanitiseWarehousesInAnswers(answers: UserAnswers, subscription: RetrievedSubscription) = {
+    if (!UserTypeCheck.isNewImporter(SdilReturn.apply(answers), subscription)) {
+      answers.copy(warehouseList = Map.empty)
+    } else {
+      answers
+    }
   }
 }

--- a/app/controllers/HowManyAsAContractPackerController.scala
+++ b/app/controllers/HowManyAsAContractPackerController.scala
@@ -68,7 +68,7 @@ class HowManyAsAContractPackerController @Inject()(
           val updatedUserAnswers = request.userAnswers.set(
             HowManyAsAContractPackerPage, value)
 
-          updateDatabaseAndRedirect(updatedUserAnswers, HowManyAsAContractPackerPage, mode)
+          updateDatabaseAndRedirect(updatedUserAnswers, HowManyAsAContractPackerPage, mode, true, Some(request.subscription))
         }
       )
   }

--- a/app/controllers/PackagedContractPackerController.scala
+++ b/app/controllers/PackagedContractPackerController.scala
@@ -67,8 +67,7 @@ class PackagedContractPackerController @Inject()(
           Future.successful(BadRequest(view(formWithErrors, mode))),
 
         value => {
-          val updatedUserAnswers = request.userAnswers.setAndRemoveLitresIfReq(
-            PackagedContractPackerPage, HowManyAsAContractPackerPage, value)
+          val updatedUserAnswers = request.userAnswers.setAndRemoveLitresIfReq(PackagedContractPackerPage, HowManyAsAContractPackerPage, value)
           updateDatabaseAndRedirect(updatedUserAnswers, PackagedContractPackerPage, mode)
         }
       )

--- a/app/controllers/SmallProducerDetailsController.scala
+++ b/app/controllers/SmallProducerDetailsController.scala
@@ -66,7 +66,7 @@ class SmallProducerDetailsController @Inject()(
 
         value => {
           val updatedUserAnswers = request.userAnswers.set(SmallProducerDetailsPage, value)
-          updateDatabaseAndRedirect(updatedUserAnswers, SmallProducerDetailsPage, mode)
+          updateDatabaseAndRedirect(updatedUserAnswers, SmallProducerDetailsPage, mode, true, Some(request.subscription))
         }
       )
   }

--- a/app/utilitlies/UserTypeCheck.scala
+++ b/app/utilitlies/UserTypeCheck.scala
@@ -22,7 +22,7 @@ import models.retrieved.RetrievedSubscription
 
 object UserTypeCheck {
   def isNewImporter(sdilReturn: SdilReturn,subscription: RetrievedSubscription): Boolean = {
-  (sdilReturn.totalImported._1 > 0L && sdilReturn.totalImported._2 > 0L) && !subscription.activity.importer && subscription.warehouseSites.isEmpty
+  (sdilReturn.totalImported._1 > 0L && sdilReturn.totalImported._2 > 0L) && !subscription.activity.importer
 }
   def isNewPacker(sdilReturn: SdilReturn, subscription: RetrievedSubscription): Boolean = {
     (sdilReturn.totalPacked._1 > 0L && sdilReturn.totalPacked._2 > 0L) && !subscription.activity.contractPacker

--- a/app/views/helpers/returnDetails/AskSecondaryWarehouseSummary.scala
+++ b/app/views/helpers/returnDetails/AskSecondaryWarehouseSummary.scala
@@ -18,7 +18,6 @@ package views.helpers.returnDetails
 
 import controllers.routes
 import models.{CheckMode, UserAnswers}
-import pages.AskSecondaryWarehouseInReturnPage
 import play.api.i18n.Messages
 import uk.gov.hmrc.govukfrontend.views.Aliases.{SummaryList, Value}
 import viewmodels.govuk.summarylist._
@@ -28,8 +27,9 @@ object AskSecondaryWarehouseSummary {
 
   def summaryList(userAnswers: UserAnswers, isCheckAnswers: Boolean)
                  (implicit messages: Messages): Option[SummaryList] = {
-    userAnswers.get(AskSecondaryWarehouseInReturnPage) match {
-      case Some(true) =>
+
+    userAnswers.warehouseList.nonEmpty match{
+      case true =>
         Some(
           SummaryListViewModel(
             rows = Seq(SummaryListRowViewModel(
@@ -40,7 +40,7 @@ object AskSecondaryWarehouseSummary {
               value = Value(),
               actions = if (isCheckAnswers) {
                 Seq(
-                  ActionItemViewModel("site.change", routes.AskSecondaryWarehouseInReturnController.onPageLoad(CheckMode).url)
+                  ActionItemViewModel("site.change", routes.SecondaryWarehouseDetailsController.onPageLoad(CheckMode).url)
                     .withAttribute(("id", "change-packaging-sites"))
                     .withVisuallyHiddenText(messages("SecondaryWarehouse.change.hidden"))
                 )

--- a/test/controllers/CheckYourAnswersControllerSpec.scala
+++ b/test/controllers/CheckYourAnswersControllerSpec.scala
@@ -318,7 +318,7 @@ class CheckYourAnswersControllerSpec extends SpecBase with SummaryListFluency wi
       val userAnswers = UserAnswers(sdilNumber, userAnswersData, List())
       val application = withRequiredAnswersComplete(applicationBuilder(Some(userAnswers))).overrides(
         bind[ReturnsOrchestrator].toInstance(mockOrchestrator)
-        
+
       ).build()
       running(application) {
         when(mockOrchestrator.calculateAmounts(any(), any(), any())(any(), any())) thenReturn(Future.successful(amounts))
@@ -847,8 +847,13 @@ class CheckYourAnswersControllerSpec extends SpecBase with SummaryListFluency wi
       }
     }
 
-    "must show packaging site section if the user selected the default packaging site we presented to them during the journey" in {
-      val userAnswersData = Json.obj("packAtBusinessAddress" -> true)
+    "must show packaging site section if the user is a new packer and " +
+      "selected the default packaging site we presented to them during the journey" in {
+      val userAnswersData = Json.obj(
+        "packagedContractPacker" -> true,
+        "howManyAsAContractPacker" -> Json.obj("lowBand" -> 10000, "highBand" -> 10000),
+        "packAtBusinessAddress" -> true)
+
       val userAnswers = UserAnswers(sdilNumber, userAnswersData, packagingSiteList = packagingSiteListWith1)
       val application = withRequiredAnswersComplete(applicationBuilder(Some(userAnswers))).overrides(
         bind[ReturnsOrchestrator].toInstance(mockOrchestrator)
@@ -866,7 +871,11 @@ class CheckYourAnswersControllerSpec extends SpecBase with SummaryListFluency wi
     }
 
     "must show packaging site section if the user changed the default packaging site we presented to them during the journey" in {
-      val userAnswersData = Json.obj("packAtBusinessAddress" -> false)
+      val userAnswersData = Json.obj(
+        "packAtBusinessAddress" -> false,
+        "packAtBusinessAddress" -> false,
+        "howManyAsAContractPacker" -> Json.obj("lowBand" -> 10000, "highBand" -> 10000))
+
       val userAnswers = UserAnswers(sdilNumber, userAnswersData, packagingSiteList = packagingSiteListWith1)
       val application = withRequiredAnswersComplete(applicationBuilder(Some(userAnswers))).overrides(
         bind[ReturnsOrchestrator].toInstance(mockOrchestrator)
@@ -884,7 +893,12 @@ class CheckYourAnswersControllerSpec extends SpecBase with SummaryListFluency wi
     }
 
     "must show correct number of packaging sites if multiple packaging sites present" in {
-      val userAnswers = UserAnswers(sdilNumber, Json.obj(), packagingSiteList = packagingSiteListWith2)
+      val userAnswers = UserAnswers(sdilNumber,
+        Json.obj(
+        "packAtBusinessAddress" -> false,
+        "howManyAsAContractPacker" -> Json.obj("lowBand" -> 10000, "highBand" -> 10000)),
+        packagingSiteList = packagingSiteListWith2)
+
       val application = withRequiredAnswersComplete(applicationBuilder(Some(userAnswers))).overrides(
         bind[ReturnsOrchestrator].toInstance(mockOrchestrator)
       ).build()
@@ -901,7 +915,11 @@ class CheckYourAnswersControllerSpec extends SpecBase with SummaryListFluency wi
     }
 
     "must show correct number of warehouses if multiple are present" in {
-      val userAnswersData = Json.obj("askSecondaryWarehouseInReturn" -> true)
+      val userAnswersData = Json.obj(
+        "broughtIntoUK" -> true,
+        "HowManyBroughtIntoUk" -> Json.obj("lowBand" -> 10000, "highBand" -> 20000),
+        "askSecondaryWarehouseInReturn" -> true
+      )
       val userAnswers = UserAnswers(sdilNumber, userAnswersData, packagingSiteList = packagingSiteListWith1, warehouseList = warhouseSiteListWith2)
       val application = withRequiredAnswersComplete(applicationBuilder(Some(userAnswers))).overrides(
         bind[ReturnsOrchestrator].toInstance(mockOrchestrator)
@@ -919,7 +937,10 @@ class CheckYourAnswersControllerSpec extends SpecBase with SummaryListFluency wi
     }
 
     "must return OK and contain registered UK sites section header when warehouse site present" in {
-      val userAnswersData = Json.obj("askSecondaryWarehouseInReturn" -> true)
+      val userAnswersData = Json.obj(
+        "broughtIntoUK" -> true,
+        "HowManyBroughtIntoUk" -> Json.obj("lowBand" -> 10000, "highBand" -> 20000),
+        "askSecondaryWarehouseInReturn" -> true)
       val userAnswers = UserAnswers(sdilNumber, userAnswersData, warehouseList = warhouseSiteListWith1)
       val application = withRequiredAnswersComplete(applicationBuilder(Some(userAnswers))).overrides(
         bind[ReturnsOrchestrator].toInstance(mockOrchestrator)

--- a/test/navigation/NavigatorSpec.scala
+++ b/test/navigation/NavigatorSpec.scala
@@ -791,21 +791,28 @@ class NavigatorSpec extends SpecBase with LoggerHelper {
           ) mustBe routes.HowManyAsAContractPackerController.onPageLoad(CheckMode)
         }
 
-        "Should navigate to Check Your Answers page when yes is selected and data present" in {
-          navigator.nextPage(HowManyAsAContractPackerPage,
+        "Should navigate to Check Your Answers page when yes is selected and not a new packer" in {
+          val answers = UserAnswers(id,
+            Json.obj(
+              "packagedContractPacker" -> true,
+              "howManyAsAContractPacker" -> Json.obj("lowBand" -> "100", "highBand" -> "100")))
+
+          navigator.nextPage(
+            HowManyAsAContractPackerPage,
             CheckMode,
-            UserAnswers(id, Json.obj("packagedContractPacker" -> true,
-              "howManyAsAContractPacker" ->
-                Json.obj("lowBand" -> "100", "highBand" -> "100")))
+            answers,
+            Some(SdilReturn.apply(answers)),
+            Some(aSubscription)
           ) mustBe routes.CheckYourAnswersController.onPageLoad
         }
 
       }
 
-      "Exemption for small producer " - {
+      "Exemption for small producer" - {
 
         "Should navigate to Check Your Answers page when no is selected" in {
-          navigator.nextPage(ExemptionsForSmallProducersPage, CheckMode, UserAnswers(id, Json.obj("exemptionsForSmallProducers" -> false))
+          val answers = UserAnswers(id, Json.obj("exemptionsForSmallProducers" -> false))
+          navigator.nextPage(ExemptionsForSmallProducersPage, CheckMode, answers, Some(SdilReturn.apply(answers)),Some(aSubscription)
           ) mustBe routes.CheckYourAnswersController.onPageLoad
         }
 
@@ -910,8 +917,30 @@ class NavigatorSpec extends SpecBase with LoggerHelper {
       "Check small producer details" - {
 
         "Should navigate to Check Your Answers page when no is selected" in {
-          navigator.nextPage(SmallProducerDetailsPage, CheckMode, UserAnswers(id, Json.obj("smallProducerDetails" -> false))
+          val answers = UserAnswers(id, Json.obj("smallProducerDetails" -> false))
+          navigator.nextPage(SmallProducerDetailsPage, CheckMode, answers, Some(SdilReturn.apply(answers)), Some(aSubscription)
           ) mustBe routes.CheckYourAnswersController.onPageLoad
+        }
+
+        "Should navigate to pack at business address page when no is selected but user is new packer" in {
+          val answers = UserAnswers(id, Json.obj(
+            "addASmallProducer" -> Json.obj("lowBand" -> "10000", "highBand" -> "20000"),
+            "smallProducerDetails" -> false),
+            List(superCola))
+          navigator.nextPage(
+            SmallProducerDetailsPage, CheckMode, answers, Some(SdilReturn.apply(answers)),
+            Some(aSubscription.copy(productionSites = List.empty))
+          ) mustBe routes.PackAtBusinessAddressController.onPageLoad(CheckMode)
+        }
+
+        "Should navigate to journey recovery page when no is selected but no return nor Subscription is available" in {
+          val answers = UserAnswers(id, Json.obj(
+            "addASmallProducer" -> Json.obj("lowBand" -> "10000", "highBand" -> "20000"),
+            "smallProducerDetails" -> false),
+            List(superCola))
+          navigator.nextPage(
+            SmallProducerDetailsPage, CheckMode, answers, None, None
+          ) mustBe routes.JourneyRecoveryController.onPageLoad()
         }
 
         "Should navigate to how many credits for lost or damaged page when yes is selected" in {


### PR DESCRIPTION
DLS-8683: conditonal loading of packaging sites on check your anwers

DLS-8683: Update tests to test for new behaviour of CYA around packaging sites

DLS-8683: Add more tests to packaging site on CYA

DLS-8683: ensure warehouses are only displayed if a warehouses are added by the user in cases where user is new importer

DLS-8683: change redirect location of change on warehouses to point to warehouse details page

DLS-8683: add logic to change of status to new importer in check mode

DLS-8683: add logic for navigation when new packer status

DLS-8683: add logic for clearing cache on pack at business address page

DLS-8683: set log level to INFO

DLS-8683: add a test to cover an edge case

DLS-8683: clean up