### PR TITLE
DLS-8500 [a11y] Fix heading hierarchy in details component on return-sent page

### DIFF
--- a/app/views/ReturnSentView.scala.html
+++ b/app/views/ReturnSentView.scala.html
@@ -42,6 +42,11 @@
   amountOwed:String,
   levyCalculations: Map[(Long, Long), LevyCalculation])(implicit request: Request[?], messages: Messages, config: FrontendAppConfig)
 
+@detailsContent = {
+    <h2 class="govuk-visually-hidden" id="returnDetailsHeading">@messages("returnSent.details")</h2>
+    @returnDetailsSummary(returnPeriod, userAnswers, amounts, false, subscription.activity.smallProducer, levyCalculations, headingLevel = 3)
+}
+
 @layout(pageTitle = titleNoForm(messages("returnSent.title")), showBackLink = false){
 
 @govukPanel(Panel(
@@ -118,7 +123,7 @@
 
     @govukDetails(Details(
         summary = Text(Messages("returnSent.details")),
-        content = HtmlContent(Html(s"${returnDetailsSummary(returnPeriod, userAnswers, amounts, false, subscription.activity.smallProducer, levyCalculations)}"))
+        content = HtmlContent(detailsContent)
     ))
 
 }

--- a/app/views/helpers/returnDetailsSummary.scala.html
+++ b/app/views/helpers/returnDetailsSummary.scala.html
@@ -30,36 +30,45 @@ govukSummaryList: GovukSummaryList
   amounts: Amounts,
   isCheckAnswers: Boolean,
   isSmallProducer: Boolean,
-  levyCalculations: Map[(Long, Long), LevyCalculation])(implicit request: Request[?], messages: Messages, config: FrontendAppConfig)
+  levyCalculations: Map[(Long, Long), LevyCalculation],
+  headingLevel: Int = 2)(implicit request: Request[?], messages: Messages, config: FrontendAppConfig)
+
+@sectionHeading(id: String, msgKey: String) = {
+  @if(headingLevel == 3) {
+   <h3 class="govuk-heading-m" id="@id">@messages(msgKey)</h3>
+  } else {
+   <h2 class="govuk-heading-m" id="@id">@messages(msgKey)</h2>
+  }
+}
 
  @if(!isSmallProducer) {
-  <h2 class="govuk-heading-m" id="ownBrandsPackagedAtYourOwnSite">@messages("ownBrandsPackagedAtYourOwnSite")</h2>
+  @sectionHeading("ownBrandsPackagedAtYourOwnSite", "ownBrandsPackagedAtYourOwnSite")
   @govukSummaryList(OwnBrandsSummary.summaryList(userAnswers, isCheckAnswers, levyCalculations))
  }
 
-<h2 class="govuk-heading-m" id="contractPackedAtYourOwnSite">@messages("contractPackedAtYourOwnSite")</h2>
+@sectionHeading("contractPackedAtYourOwnSite", "contractPackedAtYourOwnSite")
 @govukSummaryList(PackagedContractPackerSummary.summaryList(userAnswers, isCheckAnswers, levyCalculations))
 
-<h2 class="govuk-heading-m" id="contractPackedForRegisteredSmallProducers">@messages("contractPackedForRegisteredSmallProducers")</h2>
+@sectionHeading("contractPackedForRegisteredSmallProducers", "contractPackedForRegisteredSmallProducers")
 @govukSummaryList(ExemptionsForSmallProducersSummary.summaryList(userAnswers, isCheckAnswers, levyCalculations))
 
-<h2 class="govuk-heading-m" id="broughtIntoUK">@messages("broughtIntoUK")</h2>
+@sectionHeading("broughtIntoUK", "broughtIntoUK")
 @govukSummaryList(BroughtIntoUKSummary.summaryList(userAnswers, isCheckAnswers, levyCalculations))
 
-<h2 class="govuk-heading-m" id="broughtIntoTheUKFromSmallProducers">@messages("broughtIntoTheUKFromSmallProducers")</h2>
+@sectionHeading("broughtIntoTheUKFromSmallProducers", "broughtIntoTheUKFromSmallProducers")
 @govukSummaryList(BroughtIntoUkFromSmallProducersSummary.summaryList(userAnswers, isCheckAnswers, levyCalculations))
 
-<h2 class="govuk-heading-m" id="exported">@messages("exported")</h2>
+@sectionHeading("exported", "exported")
 @govukSummaryList(ClaimCreditsForExportsSummary.summaryList(userAnswers, isCheckAnswers, levyCalculations))
 
-<h2 class="govuk-heading-m" id="lostOrDestroyed">@messages("lostOrDestroyed")</h2>
+@sectionHeading("lostOrDestroyed", "lostOrDestroyed")
 @govukSummaryList(ClaimCreditsForLostDamagedSummary.summaryList(userAnswers, isCheckAnswers, levyCalculations))
 
-<h2 class="govuk-heading-m" id="amount-to-pay-title">@messages("summary")</h2>
+@sectionHeading("amount-to-pay-title", "summary")
 @govukSummaryList(AmountToPaySummary.amountToPaySummary(amounts))
 
 @if(userAnswers.packagingSiteList.nonEmpty || userAnswers.warehouseList.nonEmpty){
- <h2 class="govuk-heading-m" id="registeredUkSites">@messages("registeredUkSites")</h2>
+ @sectionHeading("registeredUkSites", "registeredUkSites")
 }
 
 @PackAtBusinessAddressSummary.summaryList(userAnswers, isCheckAnswers) match {

--- a/test/controllers/ReturnSentControllerSpec.scala
+++ b/test/controllers/ReturnSentControllerSpec.scala
@@ -81,7 +81,7 @@ class ReturnSentControllerSpec extends SpecBase with SummaryListFluency with Bef
 
         status(result) mustEqual OK
         val page = Jsoup.parse(contentAsString(result))
-        page.getElementsByTag("h2").text() must include(Messages("returnSent.ownBrands"))
+        page.getElementsByTag("h3").text() must include(Messages("returnSent.ownBrands"))
         page.getElementsByTag("dt").text() must include(Messages("ReportingOwnBrandsPackagedAtYourOwnSite.checkYourAnswersLabel"))
       }
     }
@@ -102,7 +102,7 @@ class ReturnSentControllerSpec extends SpecBase with SummaryListFluency with Bef
 
         status(result) mustEqual OK
         val page = Jsoup.parse(contentAsString(result))
-        page.getElementsByTag("h2").text() must include(Messages("returnSent.ownBrands"))
+        page.getElementsByTag("h3").text() must include(Messages("returnSent.ownBrands"))
         page.getElementsByTag("dt").text() must include(Messages("ReportingOwnBrandsPackagedAtYourOwnSite.checkYourAnswersLabel"))
 
         page.getElementsByTag("dt").text() must include(Messages("litresInTheLowBand"))
@@ -133,7 +133,7 @@ class ReturnSentControllerSpec extends SpecBase with SummaryListFluency with Bef
 
         status(result) mustEqual OK
         val page = Jsoup.parse(contentAsString(result))
-        page.getElementsByTag("h2").text() must include(Messages("returnSent.ownBrands"))
+        page.getElementsByTag("h3").text() must include(Messages("returnSent.ownBrands"))
         page.getElementsByTag("dt").text() must include(Messages("ReportingOwnBrandsPackagedAtYourOwnSite.checkYourAnswersLabel"))
 
         page.getElementsByTag("dt").text() must include(Messages("litresInTheLowBand"))
@@ -164,7 +164,7 @@ class ReturnSentControllerSpec extends SpecBase with SummaryListFluency with Bef
 
         status(result) mustEqual OK
         val page = Jsoup.parse(contentAsString(result))
-        page.getElementsByTag("h2").text() must include(Messages("returnSent.packagedContractPacker"))
+        page.getElementsByTag("h3").text() must include(Messages("returnSent.packagedContractPacker"))
         page.getElementsByTag("dt").text() must include(Messages("reportingContractPackedAtYourOwnSite.checkYourAnswersLabel"))
       }
     }
@@ -185,7 +185,7 @@ class ReturnSentControllerSpec extends SpecBase with SummaryListFluency with Bef
 
         status(result) mustEqual OK
         val page = Jsoup.parse(contentAsString(result))
-        page.getElementsByTag("h2").text() must include(Messages("returnSent.packagedContractPacker"))
+        page.getElementsByTag("h3").text() must include(Messages("returnSent.packagedContractPacker"))
         page.getElementsByTag("dt").text() must include(Messages("reportingContractPackedAtYourOwnSite.checkYourAnswersLabel"))
 
         page.getElementsByTag("dt").text() must include(Messages("litresInTheLowBand"))
@@ -216,7 +216,7 @@ class ReturnSentControllerSpec extends SpecBase with SummaryListFluency with Bef
 
         status(result) mustEqual OK
         val page = Jsoup.parse(contentAsString(result))
-        page.getElementsByTag("h2").text() must include(Messages("returnSent.packagedContractPacker"))
+        page.getElementsByTag("h3").text() must include(Messages("returnSent.packagedContractPacker"))
         page.getElementsByTag("dt").text() must include(Messages("reportingContractPackedAtYourOwnSite.checkYourAnswersLabel"))
 
         page.getElementsByTag("dt").text() must include(Messages("litresInTheLowBand"))
@@ -247,7 +247,7 @@ class ReturnSentControllerSpec extends SpecBase with SummaryListFluency with Bef
 
         status(result) mustEqual OK
         val page = Jsoup.parse(contentAsString(result))
-        page.getElementsByTag("h2").text() must include(Messages("returnSent.exemptionsForSmallProducers"))
+        page.getElementsByTag("h3").text() must include(Messages("returnSent.exemptionsForSmallProducers"))
         page.getElementsByTag("dt").text() must include(Messages("exemptionForRegisteredSmallProducers"))
       }
     }
@@ -276,7 +276,7 @@ class ReturnSentControllerSpec extends SpecBase with SummaryListFluency with Bef
 
         status(result) mustEqual OK
         val page = Jsoup.parse(contentAsString(result))
-        page.getElementsByTag("h2").text() must include(Messages("returnSent.exemptionsForSmallProducers"))
+        page.getElementsByTag("h3").text() must include(Messages("returnSent.exemptionsForSmallProducers"))
         page.getElementsByTag("dt").text() must include(Messages("exemptionForRegisteredSmallProducers"))
 
         page.getElementsByTag("dt").text() must include(Messages("litresInTheLowBand"))
@@ -315,7 +315,7 @@ class ReturnSentControllerSpec extends SpecBase with SummaryListFluency with Bef
 
         status(result) mustEqual OK
         val page = Jsoup.parse(contentAsString(result))
-        page.getElementsByTag("h2").text() must include(Messages("returnSent.exemptionsForSmallProducers"))
+        page.getElementsByTag("h3").text() must include(Messages("returnSent.exemptionsForSmallProducers"))
         page.getElementsByTag("dt").text() must include(Messages("exemptionForRegisteredSmallProducers"))
 
         page.getElementsByTag("dt").text() must include(Messages("litresInTheLowBand"))
@@ -346,7 +346,7 @@ class ReturnSentControllerSpec extends SpecBase with SummaryListFluency with Bef
 
         status(result) mustEqual OK
         val page = Jsoup.parse(contentAsString(result))
-        page.getElementsByTag("h2").text() must include(Messages("returnSent.broughtIntoUk"))
+        page.getElementsByTag("h3").text() must include(Messages("returnSent.broughtIntoUk"))
         page.getElementsByTag("dt").text() must include(Messages("broughtIntoUK.checkYourAnswersLabel"))
       }
     }
@@ -367,7 +367,7 @@ class ReturnSentControllerSpec extends SpecBase with SummaryListFluency with Bef
 
         status(result) mustEqual OK
         val page = Jsoup.parse(contentAsString(result))
-        page.getElementsByTag("h2").text() must include(Messages("returnSent.broughtIntoUk"))
+        page.getElementsByTag("h3").text() must include(Messages("returnSent.broughtIntoUk"))
         page.getElementsByTag("dt").text() must include(Messages("broughtIntoUK.checkYourAnswersLabel"))
 
         page.getElementsByTag("dt").text() must include(Messages("litresInTheLowBand"))
@@ -398,7 +398,7 @@ class ReturnSentControllerSpec extends SpecBase with SummaryListFluency with Bef
 
         status(result) mustEqual OK
         val page = Jsoup.parse(contentAsString(result))
-        page.getElementsByTag("h2").text() must include(Messages("returnSent.broughtIntoUk"))
+        page.getElementsByTag("h3").text() must include(Messages("returnSent.broughtIntoUk"))
         page.getElementsByTag("dt").text() must include(Messages("broughtIntoUK.checkYourAnswersLabel"))
 
         page.getElementsByTag("dt").text() must include(Messages("litresInTheLowBand"))
@@ -429,7 +429,7 @@ class ReturnSentControllerSpec extends SpecBase with SummaryListFluency with Bef
 
         status(result) mustEqual OK
         val page = Jsoup.parse(contentAsString(result))
-        page.getElementsByTag("h2").text() must include(Messages("returnSent.broughtIntoUkSmallProducer"))
+        page.getElementsByTag("h3").text() must include(Messages("returnSent.broughtIntoUkSmallProducer"))
         page.getElementsByTag("dt").text() must include(Messages("broughtIntoUKFromSmallProducers.checkYourAnswersLabel"))
       }
     }
@@ -453,7 +453,7 @@ class ReturnSentControllerSpec extends SpecBase with SummaryListFluency with Bef
 
         status(result) mustEqual OK
         val page = Jsoup.parse(contentAsString(result))
-        page.getElementsByTag("h2").text() must include(Messages("returnSent.broughtIntoUkSmallProducer"))
+        page.getElementsByTag("h3").text() must include(Messages("returnSent.broughtIntoUkSmallProducer"))
         page.getElementsByTag("dt").text() must include(Messages("broughtIntoUKFromSmallProducers.checkYourAnswersLabel"))
 
         page.getElementsByTag("dt").text() must include(Messages("litresInTheLowBand"))
@@ -487,7 +487,7 @@ class ReturnSentControllerSpec extends SpecBase with SummaryListFluency with Bef
 
         status(result) mustEqual OK
         val page = Jsoup.parse(contentAsString(result))
-        page.getElementsByTag("h2").text() must include(Messages("returnSent.broughtIntoUkSmallProducer"))
+        page.getElementsByTag("h3").text() must include(Messages("returnSent.broughtIntoUkSmallProducer"))
         page.getElementsByTag("dt").text() must include(Messages("broughtIntoUKFromSmallProducers.checkYourAnswersLabel"))
 
         page.getElementsByTag("dt").text() must include(Messages("litresInTheLowBand"))
@@ -518,7 +518,7 @@ class ReturnSentControllerSpec extends SpecBase with SummaryListFluency with Bef
 
         status(result) mustEqual OK
         val page = Jsoup.parse(contentAsString(result))
-        page.getElementsByTag("h2").text() must include(Messages("returnSent.exported"))
+        page.getElementsByTag("h3").text() must include(Messages("returnSent.exported"))
         page.getElementsByTag("dt").text() must include(Messages("claimingCreditForExportedLiableDrinks"))
       }
     }
@@ -539,7 +539,7 @@ class ReturnSentControllerSpec extends SpecBase with SummaryListFluency with Bef
 
         status(result) mustEqual OK
         val page = Jsoup.parse(contentAsString(result))
-        page.getElementsByTag("h2").text() must include(Messages("returnSent.exported"))
+        page.getElementsByTag("h3").text() must include(Messages("returnSent.exported"))
         page.getElementsByTag("dt").text() must include(Messages("claimingCreditForExportedLiableDrinks"))
 
         page.getElementsByTag("dt").text() must include(Messages("litresInTheLowBand"))
@@ -570,7 +570,7 @@ class ReturnSentControllerSpec extends SpecBase with SummaryListFluency with Bef
 
         status(result) mustEqual OK
         val page = Jsoup.parse(contentAsString(result))
-        page.getElementsByTag("h2").text() must include(Messages("returnSent.exported"))
+        page.getElementsByTag("h3").text() must include(Messages("returnSent.exported"))
         page.getElementsByTag("dt").text() must include(Messages("claimingCreditForExportedLiableDrinks"))
 
         page.getElementsByTag("dt").text() must include(Messages("litresInTheLowBand"))
@@ -601,7 +601,7 @@ class ReturnSentControllerSpec extends SpecBase with SummaryListFluency with Bef
 
         status(result) mustEqual OK
         val page = Jsoup.parse(contentAsString(result))
-        page.getElementsByTag("h2").text() must include(Messages("returnSent.lostDestroyed"))
+        page.getElementsByTag("h3").text() must include(Messages("returnSent.lostDestroyed"))
         page.getElementsByTag("dt").text() must include(Messages("claimCreditsForLostDamaged.checkYourAnswersLabel"))
       }
     }
@@ -622,7 +622,7 @@ class ReturnSentControllerSpec extends SpecBase with SummaryListFluency with Bef
 
         status(result) mustEqual OK
         val page = Jsoup.parse(contentAsString(result))
-        page.getElementsByTag("h2").text() must include(Messages("returnSent.lostDestroyed"))
+        page.getElementsByTag("h3").text() must include(Messages("returnSent.lostDestroyed"))
         page.getElementsByTag("dt").text() must include(Messages("claimCreditsForLostDamaged.checkYourAnswersLabel"))
 
         page.getElementsByTag("dt").text() must include(Messages("litresInTheLowBand"))
@@ -653,7 +653,7 @@ class ReturnSentControllerSpec extends SpecBase with SummaryListFluency with Bef
 
         status(result) mustEqual OK
         val page = Jsoup.parse(contentAsString(result))
-        page.getElementsByTag("h2").text() must include(Messages("returnSent.lostDestroyed"))
+        page.getElementsByTag("h3").text() must include(Messages("returnSent.lostDestroyed"))
         page.getElementsByTag("dt").text() must include(Messages("claimCreditsForLostDamaged.checkYourAnswersLabel"))
 
         page.getElementsByTag("dt").text() must include(Messages("litresInTheLowBand"))

--- a/test/views/ReturnSentViewSpec.scala
+++ b/test/views/ReturnSentViewSpec.scala
@@ -181,6 +181,12 @@ class ReturnSentViewSpec extends ReturnDetailsSummaryRowTestHelper {
           val details = document.getElementsByClass(Selectors.details).get(0)
           details.getElementsByClass(Selectors.detailsText).text() mustEqual "View the details of your return"
         }
+        "that has a visually hidden heading for the details content" in {
+          val detailsHeading = document.getElementById("returnDetailsHeading")
+          detailsHeading.tagName() mustEqual "h2"
+          detailsHeading.className() mustEqual "govuk-visually-hidden"
+          detailsHeading.text() mustEqual Messages("returnSent.details")
+        }
         "has contains the expected content" -
           UserAnswersTestData.userAnswersModels.foreach { case (key, userAnswers) =>
             val preApril2025ReturnPeriod = ReturnPeriod(2025, 0)
@@ -193,7 +199,7 @@ class ReturnSentViewSpec extends ReturnDetailsSummaryRowTestHelper {
                   returnSentView(returnPeriod, userAnswersWithReturnPeriod, amounts, aSubscription, amountOwed, levyCalcs)
                 val document1: Document = doc(html1)
                 val details = document1.getElementsByClass(Selectors.details).get(0)
-                testSummaryLists(key, details, userAnswersWithReturnPeriod, false)
+                testSummaryLists(key, details, userAnswersWithReturnPeriod, false, expectedHeadingLevel = 3)
               }
             )
           }

--- a/test/views/helpers/ReturnDetailsSummaryRowTestHelper.scala
+++ b/test/views/helpers/ReturnDetailsSummaryRowTestHelper.scala
@@ -46,7 +46,7 @@ trait ReturnDetailsSummaryRowTestHelper extends ViewSpecHelper with ReturnDetail
     val button           = "govuk-button"
   }
 
-  def testSummaryLists(key: String, element: Element, userAnswers: UserAnswers, isCheckAnswers: Boolean) = {
+  def testSummaryLists(key: String, element: Element, userAnswers: UserAnswers, isCheckAnswers: Boolean, expectedHeadingLevel: Int = 2) = {
     val summaryLists = element.getElementsByClass(Selectors.summaryList)
 
     returnDetailsSummaryListsWithListNames.foreach { case (subHeaderId, listName) =>
@@ -56,7 +56,7 @@ trait ReturnDetailsSummaryRowTestHelper extends ViewSpecHelper with ReturnDetail
         val arrayElementNumber = returnDetailsSummaryListsWithArrayElement(subHeaderId)
         val summaryList: Element = summaryLists.get(arrayElementNumber)
         s"should include an $listName section" - {
-          testSummaryHeading(subHeaderId, element)
+          testSummaryHeading(subHeaderId, element, expectedHeadingLevel)
           if subHeaderId == SummaryHeadingIds.registeredSites then {
             testRegisteredSites(subHeaderId, summaryList, isCheckAnswers)
           } else if subHeaderId == SummaryHeadingIds.amountToPay then {
@@ -73,7 +73,7 @@ trait ReturnDetailsSummaryRowTestHelper extends ViewSpecHelper with ReturnDetail
     }
   }
 
-  def testSummaryHeading(subHeadingId: String, element: Element) =
+  def testSummaryHeading(subHeadingId: String, element: Element, expectedHeadingLevel: Int = 2) =
     "that has the correct subheading" in {
       val expectedHeading = if subHeadingId == SummaryHeadingIds.amountToPay then {
         "summary"
@@ -82,6 +82,7 @@ trait ReturnDetailsSummaryRowTestHelper extends ViewSpecHelper with ReturnDetail
       }
       val elementSubHeading = element.getElementById(subHeadingId)
       elementSubHeading.className() mustEqual Selectors.subHeading
+      elementSubHeading.tagName() mustEqual s"h$expectedHeadingLevel"
       elementSubHeading.text() mustEqual Messages(expectedHeading)
     }
 


### PR DESCRIPTION

- Add visually-hidden h2 inside the details component for screen reader heading hierarchy
- Change section headings within details from h2 to h3 to follow from the parent h2
- Add headingLevel parameter to returnDetailsSummary helper (defaults to h2 for CYA, h3 for return-sent)
- Add test assertion for heading tag level and visually-hidden h2
