### PR TITLE
DLS-8733 [a11y] Display of SDIL on small producer [P2]

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -11,3 +11,7 @@
     padding-right: 0px !important;
   }
 }
+
+.sdil-small-producer-reference {
+  white-space: nowrap;
+}

--- a/app/views/helpers/returnDetails/SmallProducerDetailsSummary.scala
+++ b/app/views/helpers/returnDetails/SmallProducerDetailsSummary.scala
@@ -20,7 +20,9 @@ import controllers.routes
 import models.{CheckMode, EditMode, Mode, NormalMode, SmallProducer}
 import pages.{QuestionPage, SmallProducerDetailsPage}
 import play.api.i18n.Messages
-import uk.gov.hmrc.govukfrontend.views.Aliases.{SummaryList, Text}
+import play.twirl.api.HtmlFormat
+import uk.gov.hmrc.govukfrontend.views.Aliases.{SummaryList, Value}
+import uk.gov.hmrc.govukfrontend.views.viewmodels.content.HtmlContent
 import viewmodels.govuk.summarylist.*
 import viewmodels.implicits.*
 
@@ -38,10 +40,9 @@ object SmallProducerDetailsSummary extends SummaryListRowLitresHelper with Retur
 
   def producerList(mode: Mode, smallProducersList: List[SmallProducer])(implicit messages: Messages): SummaryList = {
     val rows = smallProducersList.map { smallProducer =>
-      val value = ValueViewModel(Text(smallProducer.alias))
       SummaryListRowViewModel(
-        key = smallProducer.sdilRef,
-        value = value,
+        key = KeyViewModel(HtmlContent(producerDetails(smallProducer))),
+        value = Value(),
         actions = Seq(
           ActionItemViewModel(
             "site.edit",
@@ -55,6 +56,15 @@ object SmallProducerDetailsSummary extends SummaryListRowLitresHelper with Retur
     }
 
     SummaryListViewModel(rows)
+  }
+
+  private def producerDetails(smallProducer: SmallProducer): String = {
+    val escapedAlias   = HtmlFormat.escape(smallProducer.alias).toString
+    val escapedSdilRef = HtmlFormat.escape(smallProducer.sdilRef).toString
+
+    val reference = s"""<span class="sdil-small-producer-reference">$escapedSdilRef</span>"""
+
+    if escapedAlias.isEmpty then reference else s"$escapedAlias<br>$reference"
   }
 
 }

--- a/test/views/helpers/returnDetails/SmallProducerDetailsSummarySpec.scala
+++ b/test/views/helpers/returnDetails/SmallProducerDetailsSummarySpec.scala
@@ -45,11 +45,22 @@ class SmallProducerDetailsSummarySpec extends SpecBase {
       val smallProducerDetailsSummaryRow = SmallProducerDetailsSummary.producerList(NormalMode, userAnswersWithSmallProducers.smallProducerList)
       val rowActionListItems             = smallProducerDetailsSummaryRow.rows.head.actions.toList.head.items
 
-      smallProducerDetailsSummaryRow.rows.head.key.content.asHtml.toString mustBe "XCSDIL000000069"
-      smallProducerDetailsSummaryRow.rows.head.value.content.asHtml.toString mustBe "Super Cola Plc"
+      smallProducerDetailsSummaryRow.rows.head.key.content.asHtml.toString mustBe
+        """Super Cola Plc<br><span class="sdil-small-producer-reference">XCSDIL000000069</span>"""
+      smallProducerDetailsSummaryRow.rows.head.value.content.asHtml.toString mustBe ""
       rowActionListItems.size mustBe 2
       rowActionListItems.head.content.asHtml.toString mustBe "Edit"
       rowActionListItems.last.content.asHtml.toString mustBe "Remove"
+    }
+
+    "should show the SDIL reference when the producer name is blank" in {
+      val userAnswersWithSmallProducers = emptyUserAnswers.copy(smallProducerList = List(SmallProducer("", "XMSDIL000000159", (15, 800))))
+
+      val smallProducerDetailsSummaryRow = SmallProducerDetailsSummary.producerList(NormalMode, userAnswersWithSmallProducers.smallProducerList)
+
+      smallProducerDetailsSummaryRow.rows.head.key.content.asHtml.toString mustBe
+        """<span class="sdil-small-producer-reference">XMSDIL000000159</span>"""
+      smallProducerDetailsSummaryRow.rows.head.value.content.asHtml.toString mustBe ""
     }
   }
 


### PR DESCRIPTION
small producer row now combines producer name and SDIL reference in the same summary-list cell, with the producer name first. The SDIL reference is wrapped in a small no-wrap span to prevent the visual split.